### PR TITLE
Boundary constants

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -36,37 +36,19 @@ class Home extends StatelessWidget{
           new Expanded(child:  new Column(
             mainAxisAlignment: MainAxisAlignment.spaceEvenly,
             children: <Widget>[
-              new Center(
-                  child:  new RaisedButton(
-                      onPressed: () {
-                        Navigator.push(
-                          context,
-                          new MaterialPageRoute(builder: (context) => new ImageViewScreen(imageUrl2)),
-                        );
-                      },
-                      color: Colors.green,
-                      child: new Text("open small image",
-                        style: new TextStyle(
-                            color: Colors.white,
-                            fontWeight: FontWeight.bold
-                        ),)
-                  )
+              buildOption(
+                context,
+                text: "open small image",
+                imageUrl: imageUrl2,
+                minScale: 0.1,
+                maxScale: 1.05
               ),
-              new Center(
-                  child:  new RaisedButton(
-                      onPressed: () {
-                        Navigator.push(
-                          context,
-                          new MaterialPageRoute(builder: (context) => new ImageViewScreen(imageUrl)),
-                        );
-                      },
-                      color: Colors.green,
-                      child: new Text("open large image",
-                        style: new TextStyle(
-                            color: Colors.white,
-                            fontWeight: FontWeight.bold
-                        ),)
-                  )
+              buildOption(
+                  context,
+                  text: "open large image",
+                  imageUrl: imageUrl,
+                  minScale: PhotoViewScaleBoundary.contained,
+                  maxScale: PhotoViewScaleBoundary.covered
               ),
             ],
           ))
@@ -76,14 +58,49 @@ class Home extends StatelessWidget{
       ),
     );
   }
+
+
+  Widget buildOption(BuildContext context, {
+    String text,
+    String imageUrl,
+    minScale,
+    maxScale
+  }) {
+    return new Center(
+      child: new RaisedButton(
+        onPressed: () {
+          Navigator.push(
+            context,
+            new MaterialPageRoute(builder: (context) => new ImageViewScreen(
+              imageUrl,
+              minScale: minScale,
+              maxScale: maxScale,
+            )),
+          );
+        },
+        color: Colors.green,
+        child: new Text(text,
+          style: new TextStyle(
+              color: Colors.white,
+              fontWeight: FontWeight.bold
+          ),)
+      )
+    );
+  }
 }
+
 
 
 class ImageViewScreen extends StatelessWidget {
   final String imageAddress;
 
-  ImageViewScreen(this.imageAddress);
+  var maxScale;
+  var minScale;
 
+  ImageViewScreen(this.imageAddress,{
+    @required this.minScale,
+    @required this.maxScale
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -92,8 +109,8 @@ class ImageViewScreen extends StatelessWidget {
           imageProvider: new NetworkImage(imageAddress),
           loadingChild: new LoadingText(),
           backgroundColor: Colors.white,
-          minScale: 0.1,
-          maxScale: 4.0,
+          minScale: minScale,
+          maxScale: maxScale,
         )
     );
   }

--- a/lib/photo_view.dart
+++ b/lib/photo_view.dart
@@ -3,23 +3,25 @@ library photo_view;
 import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:photo_view/photo_view_image_wrapper.dart';
-import 'package:photo_view/photo_view_scale_type.dart';
+import 'package:photo_view/photo_view_scale_boundaries.dart';
+import 'package:photo_view/photo_view_scale_state.dart';
 import 'package:photo_view/photo_view_utils.dart';
 
+export 'package:photo_view/photo_view_scale_boundary.dart';
 
 class PhotoView extends StatefulWidget{
   final ImageProvider imageProvider;
   final Widget loadingChild;
   final Color backgroundColor;
-  final double minScale;
-  final double maxScale;
+  final minScale;
+  final maxScale;
 
   PhotoView({
     Key key,
     @required this.imageProvider,
     this.loadingChild,
     this.backgroundColor = const Color.fromRGBO(0, 0, 0, 1.0),
-    this.minScale = 0.0,
+    this.minScale,
     this.maxScale,
   }) : super(key: key);
 
@@ -31,7 +33,7 @@ class PhotoView extends StatefulWidget{
 
 
 class _PhotoViewState extends State<PhotoView>{
-  PhotoViewScaleType _scaleType;
+  PhotoViewScaleState _scaleState;
 
   Future<ImageInfo> _getImage(){
     Completer completer = new Completer<ImageInfo>();
@@ -44,20 +46,20 @@ class _PhotoViewState extends State<PhotoView>{
 
   void onDoubleTap () {
     setState(() {
-      _scaleType = nextScaleType(_scaleType);
+      _scaleState = nextScaleState(_scaleState);
     });
   }
 
   void onStartPanning () {
     setState(() {
-      _scaleType = PhotoViewScaleType.zooming;
+      _scaleState = PhotoViewScaleState.zooming;
     });
   }
 
   @override
   void initState(){
     super.initState();
-    _scaleType = PhotoViewScaleType.contained;
+    _scaleState = PhotoViewScaleState.contained;
   }
   @override
   Widget build(BuildContext context) {
@@ -69,10 +71,14 @@ class _PhotoViewState extends State<PhotoView>{
               onDoubleTap: onDoubleTap,
               onStartPanning: onStartPanning,
               imageInfo: info.data,
-              scaleType: _scaleType,
+              scaleState: _scaleState,
               backgroundColor: widget.backgroundColor,
-              minScale: widget.minScale,
-              maxScale: widget.maxScale,
+              scaleBoundaries: new ScaleBoundaries(
+                widget.minScale ?? 0.0,
+                widget.maxScale ?? 100000000000.0,
+                imageInfo: info.data,
+                size: MediaQuery.of(context).size
+              ),
             );
           } else {
             return buildLoading();

--- a/lib/photo_view_scale_boundaries.dart
+++ b/lib/photo_view_scale_boundaries.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:photo_view/photo_view_scale_boundary.dart';
+import 'package:photo_view/photo_view_utils.dart';
+
+class ScaleBoundaries {
+  final _minScale;
+  final _maxScale;
+  Size size;
+  ImageInfo imageInfo;
+
+  ScaleBoundaries(this._minScale, this._maxScale, { @required this.size, @required this.imageInfo}) :
+        assert(_minScale is double || _minScale is PhotoViewScaleBoundary),
+        assert(_maxScale is double || _maxScale is PhotoViewScaleBoundary),
+        assert(computeMinScale() <= computeMaxScale());
+
+  double computeMinScale(){
+    if(_minScale == PhotoViewScaleBoundary.contained){
+      return scaleForContained(
+        size: size,
+        imageInfo: imageInfo
+      );
+    }
+    if(_minScale == PhotoViewScaleBoundary.covered){
+      return scaleForCovering(
+          size: size,
+          imageInfo: imageInfo
+      );
+    }
+    return _minScale;
+  }
+
+  double computeMaxScale(){
+    if(_maxScale == PhotoViewScaleBoundary.contained){
+      return scaleForContained(
+          size: size,
+          imageInfo: imageInfo
+      );
+    }
+    if(_maxScale == PhotoViewScaleBoundary.covered){
+      return scaleForCovering(
+          size: size,
+          imageInfo: imageInfo
+      );
+    }
+    return _maxScale;
+  }
+
+}

--- a/lib/photo_view_scale_boundary.dart
+++ b/lib/photo_view_scale_boundary.dart
@@ -1,0 +1,1 @@
+enum PhotoViewScaleBoundary{ contained, covered }

--- a/lib/photo_view_scale_state.dart
+++ b/lib/photo_view_scale_state.dart
@@ -1,3 +1,3 @@
-enum PhotoViewScaleType{
+enum PhotoViewScaleState{
   contained, covering, originalSize, zooming
 }

--- a/lib/photo_view_utils.dart
+++ b/lib/photo_view_utils.dart
@@ -1,42 +1,42 @@
 import 'dart:math' as Math;
 
 import 'package:flutter/material.dart';
-import 'package:photo_view/photo_view_scale_type.dart';
+import 'package:photo_view/photo_view_scale_state.dart';
 
 
-PhotoViewScaleType nextScaleType(PhotoViewScaleType actual){
+PhotoViewScaleState nextScaleState(PhotoViewScaleState actual){
   switch (actual) {
-    case PhotoViewScaleType.contained:
-      return PhotoViewScaleType.covering;
-    case PhotoViewScaleType.covering:
-      return PhotoViewScaleType.originalSize;
-    case PhotoViewScaleType.originalSize:
-      return PhotoViewScaleType.contained;
-    case PhotoViewScaleType.zooming:
-      return PhotoViewScaleType.contained;
+    case PhotoViewScaleState.contained:
+      return PhotoViewScaleState.covering;
+    case PhotoViewScaleState.covering:
+      return PhotoViewScaleState.originalSize;
+    case PhotoViewScaleState.originalSize:
+      return PhotoViewScaleState.contained;
+    case PhotoViewScaleState.zooming:
+      return PhotoViewScaleState.contained;
     default:
-      return PhotoViewScaleType.contained;
+      return PhotoViewScaleState.contained;
   }
 }
 
 
-double getScaleForScaleType({
+double getScaleForScaleState({
   @required Size size,
-  @required PhotoViewScaleType scaleType,
+  @required PhotoViewScaleState scaleState,
   @required ImageInfo imageInfo
 }){
-  switch (scaleType){
-    case PhotoViewScaleType.contained:
+  switch (scaleState){
+    case PhotoViewScaleState.contained:
       return scaleForContained(
-          size: size,
-          imageInfo: imageInfo
+        size: size,
+        imageInfo: imageInfo
       );
-    case PhotoViewScaleType.covering:
+    case PhotoViewScaleState.covering:
       return scaleForCovering(
-          size: size,
-          imageInfo: imageInfo
+        size: size,
+        imageInfo: imageInfo
       );
-    case PhotoViewScaleType.originalSize:
+    case PhotoViewScaleState.originalSize:
       return 1.0;
     default:
       return null;

--- a/test/photo_view_utils_test.dart
+++ b/test/photo_view_utils_test.dart
@@ -1,5 +1,10 @@
 
-import 'package:photo_view/photo_view_scale_type.dart';
+
+
+
+
+
+import 'package:photo_view/photo_view_scale_state.dart';
 import 'package:photo_view/photo_view_utils.dart';
 import 'package:test/test.dart';
 
@@ -7,31 +12,31 @@ import 'package:test/test.dart';
 void main(){
   test("nextScaleType", (){
     expect(
-      nextScaleType(PhotoViewScaleType.contained),
-      PhotoViewScaleType.covering
+      nextScaleState(PhotoViewScaleState.contained),
+      PhotoViewScaleState.covering
     );
     expect(
-      nextScaleType(PhotoViewScaleType.covering),
-      PhotoViewScaleType.originalSize
+      nextScaleState(PhotoViewScaleState.covering),
+      PhotoViewScaleState.originalSize
     );
     expect(
-      nextScaleType(PhotoViewScaleType.originalSize),
-      PhotoViewScaleType.contained
+      nextScaleState(PhotoViewScaleState.originalSize),
+      PhotoViewScaleState.contained
     );
     expect(
-      nextScaleType(PhotoViewScaleType.zooming),
-      PhotoViewScaleType.contained
+      nextScaleState(PhotoViewScaleState.zooming),
+      PhotoViewScaleState.contained
     );
     expect(
-      nextScaleType(null),
-      PhotoViewScaleType.contained
+      nextScaleState(null),
+      PhotoViewScaleState.contained
     );
   });
   
   test("getScaleForScaleType", (){
-    expect(getScaleForScaleType(
+    expect(getScaleForScaleState(
       size: null, 
-      scaleType: PhotoViewScaleType.originalSize, 
+      scaleState: PhotoViewScaleState.originalSize,
       imageInfo: null
     ), 1.0);
   });


### PR DESCRIPTION
As asked by @sgon00, this PR adds the possibility of applying the states "covered" and "contained" as ´minScale´ or ´maxScale´.

```dart
new PhotoView(
  imageProvider: imageProvider,
  loadingChild: new LoadingText(),
  backgroundColor: Colors.white,
  minScale: PhotoViewScaleBoundary.contained,
  maxScale: PhotoViewScaleBoundary.covered
);
```