### PR TITLE
Change from backgroundColor to backgroundDecoration

### DIFF
--- a/example/lib/screens/custom_child_examples.dart
+++ b/example/lib/screens/custom_child_examples.dart
@@ -48,7 +48,6 @@ class CustomChildExample extends StatelessWidget {
                           ],
                         )),
                     childSize: const Size(220.0, 250.0),
-                    backgroundColor: Colors.blue,
                     initialScale: 10.0,
                   ),
                 ),

--- a/example/lib/screens/full_screen_examples.dart
+++ b/example/lib/screens/full_screen_examples.dart
@@ -37,7 +37,8 @@ class FullScreenExamples extends StatelessWidget {
                         builder: (context) => const FullScreenWrapper(
                               imageProvider:
                                   const AssetImage("assets/small-image.jpg"),
-                              backgroundColor: Colors.pinkAccent,
+                              backgroundDecoration:
+                                  BoxDecoration(color: Colors.pinkAccent),
                             ),
                       ),
                     );
@@ -64,7 +65,8 @@ class FullScreenExamples extends StatelessWidget {
                         builder: (context) => const FullScreenWrapper(
                               imageProvider:
                                   const AssetImage("assets/peanut.gif"),
-                              backgroundColor: Colors.white,
+                              backgroundDecoration:
+                                  BoxDecoration(color: Colors.white),
                               maxScale: 2.0,
                             ),
                       ),
@@ -149,7 +151,7 @@ class ExampleButtonNode extends StatelessWidget {
 class FullScreenWrapper extends StatelessWidget {
   final ImageProvider imageProvider;
   final Widget loadingChild;
-  final Color backgroundColor;
+  final Decoration backgroundDecoration;
   final dynamic minScale;
   final dynamic maxScale;
   final dynamic initialScale;
@@ -157,7 +159,7 @@ class FullScreenWrapper extends StatelessWidget {
   const FullScreenWrapper(
       {this.imageProvider,
       this.loadingChild,
-      this.backgroundColor,
+      this.backgroundDecoration,
       this.minScale,
       this.maxScale,
       this.initialScale});
@@ -171,7 +173,7 @@ class FullScreenWrapper extends StatelessWidget {
         child: PhotoView(
           imageProvider: imageProvider,
           loadingChild: loadingChild,
-          backgroundColor: backgroundColor,
+          backgroundDecoration: backgroundDecoration,
           minScale: minScale,
           maxScale: maxScale,
           initialScale: initialScale,

--- a/example/lib/screens/gallery_example.dart
+++ b/example/lib/screens/gallery_example.dart
@@ -9,7 +9,9 @@ class GalleryExample extends StatelessWidget {
         context,
         MaterialPageRoute(
           builder: (context) => GalleryPhotoViewWrapper(
-                backgroundColor: Colors.black87,
+                backgroundDecoration: const BoxDecoration(
+                  color: Colors.black87,
+                ),
                 imageProvider: const AssetImage("assets/gallery1.jpeg"),
                 imageProvider2: const AssetImage("assets/gallery2.jpeg"),
                 imageProvider3: const AssetImage("assets/gallery3.jpeg"),
@@ -79,7 +81,7 @@ class GalleryPhotoViewWrapper extends StatefulWidget {
   final ImageProvider imageProvider2;
   final ImageProvider imageProvider3;
   final Widget loadingChild;
-  final Color backgroundColor;
+  final Decoration backgroundDecoration;
   final dynamic minScale;
   final dynamic maxScale;
   final int index;
@@ -90,7 +92,7 @@ class GalleryPhotoViewWrapper extends StatefulWidget {
     this.imageProvider2,
     this.imageProvider3,
     this.loadingChild,
-    this.backgroundColor,
+    this.backgroundDecoration,
     this.minScale,
     this.maxScale,
     this.index,
@@ -144,7 +146,7 @@ class _GalleryPhotoViewWrapperState extends State<GalleryPhotoViewWrapper> {
                   ),
                 ],
                 loadingChild: widget.loadingChild,
-                backgroundColor: widget.backgroundColor,
+                backgroundDecoration: widget.backgroundDecoration,
                 pageController: widget.pageController,
                 onPageChanged: onPageChanged,
               ),

--- a/example/lib/screens/hero_example.dart
+++ b/example/lib/screens/hero_example.dart
@@ -42,14 +42,14 @@ class HeroExample extends StatelessWidget {
 class HeroPhotoViewWrapper extends StatelessWidget {
   final ImageProvider imageProvider;
   final Widget loadingChild;
-  final Color backgroundColor;
+  final Decoration backgroundDecoration;
   final dynamic minScale;
   final dynamic maxScale;
 
   const HeroPhotoViewWrapper(
       {this.imageProvider,
       this.loadingChild,
-      this.backgroundColor,
+      this.backgroundDecoration,
       this.minScale,
       this.maxScale});
 
@@ -62,7 +62,7 @@ class HeroPhotoViewWrapper extends StatelessWidget {
         child: PhotoView(
           imageProvider: imageProvider,
           loadingChild: loadingChild,
-          backgroundColor: backgroundColor,
+          backgroundDecoration: backgroundDecoration,
           minScale: minScale,
           maxScale: maxScale,
           heroTag: "someTag",

--- a/example/lib/screens/home_screen.dart
+++ b/example/lib/screens/home_screen.dart
@@ -7,7 +7,6 @@ import './gallery_example.dart';
 import './hero_example.dart';
 import './inline_examples.dart';
 
-
 class HomeScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {

--- a/lib/photo_view.dart
+++ b/lib/photo_view.dart
@@ -26,7 +26,7 @@ typedef PhotoViewScaleStateChangedCallback = void Function(
 /// PhotoView(
 ///  imageProvider: imageProvider,
 ///  loadingChild: new LoadingText(),
-///  backgroundColor: Colors.white,
+///  backgroundDecoration: BoxDecoration(color: Colors.white),
 ///  minScale: PhotoViewComputedScale.contained,
 ///  maxScale: 2.0,
 ///  gaplessPlayback: false,
@@ -86,7 +86,8 @@ class PhotoView extends StatefulWidget {
     Key key,
     @required this.imageProvider,
     this.loadingChild,
-    this.backgroundColor = const Color.fromRGBO(0, 0, 0, 1.0),
+    this.backgroundDecoration =
+        const BoxDecoration(color: const Color.fromRGBO(0, 0, 0, 1.0)),
     this.minScale,
     this.maxScale,
     this.initialScale,
@@ -103,7 +104,8 @@ class PhotoView extends StatefulWidget {
     Key key,
     @required this.child,
     @required this.childSize,
-    this.backgroundColor = const Color.fromRGBO(0, 0, 0, 1.0),
+    this.backgroundDecoration =
+        const BoxDecoration(color: const Color.fromRGBO(0, 0, 0, 1.0)),
     this.minScale,
     this.maxScale,
     this.initialScale,
@@ -125,7 +127,7 @@ class PhotoView extends StatefulWidget {
   final Widget loadingChild;
 
   /// Changes the background behind image, defaults to `Colors.black`.
-  final Color backgroundColor;
+  final Decoration backgroundDecoration;
 
   /// Defines the minimal size in which the image will be allowed to assume, it
   /// is proportional to the original image size. Can be either a double (absolute value) or a
@@ -242,7 +244,7 @@ class _PhotoViewState extends State<PhotoView>
       onStartPanning: onStartPanning,
       childSize: _childSize,
       scaleState: _scaleState,
-      backgroundColor: widget.backgroundColor,
+      backgroundDecoration: widget.backgroundDecoration,
       size: _computedSize,
       enableRotation: widget.enableRotation,
       scaleBoundaries: ScaleBoundaries(
@@ -288,7 +290,7 @@ class _PhotoViewState extends State<PhotoView>
       imageProvider: widget.imageProvider,
       childSize: _childSize,
       scaleState: _scaleState,
-      backgroundColor: widget.backgroundColor,
+      backgroundDecoration: widget.backgroundDecoration,
       gaplessPlayback: widget.gaplessPlayback,
       size: _computedSize,
       enableRotation: widget.enableRotation,
@@ -325,7 +327,7 @@ class PhotoViewInline extends PhotoView {
     Key key,
     @required ImageProvider imageProvider,
     Widget loadingChild,
-    Color backgroundColor,
+    Decoration backgroundDecoration,
     dynamic minScale,
     dynamic maxScale,
     dynamic initialScale,
@@ -337,7 +339,7 @@ class PhotoViewInline extends PhotoView {
             key: key,
             imageProvider: imageProvider,
             loadingChild: loadingChild,
-            backgroundColor: backgroundColor,
+            backgroundDecoration: backgroundDecoration,
             minScale: minScale,
             maxScale: maxScale,
             initialScale: initialScale,

--- a/lib/photo_view_gallery.dart
+++ b/lib/photo_view_gallery.dart
@@ -11,7 +11,8 @@ class PhotoViewGallery extends StatefulWidget {
     Key key,
     @required this.pageOptions,
     this.loadingChild,
-    this.backgroundColor = const Color.fromRGBO(0, 0, 0, 1.0),
+    this.backgroundDecoration =
+        const BoxDecoration(color: const Color.fromRGBO(0, 0, 0, 1.0)),
     this.gaplessPlayback = false,
     this.pageController,
     this.onPageChanged,
@@ -20,7 +21,7 @@ class PhotoViewGallery extends StatefulWidget {
 
   final List<PhotoViewGalleryPageOptions> pageOptions;
   final Widget loadingChild;
-  final Color backgroundColor;
+  final Decoration backgroundDecoration;
   final bool gaplessPlayback;
   final PageController pageController;
   final PhotoViewGalleryPageChangedCallback onPageChanged;
@@ -73,7 +74,7 @@ class _PhotoViewGalleryState extends State<PhotoViewGallery> {
         key: ObjectKey(index),
         imageProvider: pageOption.imageProvider,
         loadingChild: widget.loadingChild,
-        backgroundColor: widget.backgroundColor,
+        backgroundDecoration: widget.backgroundDecoration,
         minScale: pageOption.minScale,
         maxScale: pageOption.maxScale,
         initialScale: pageOption.initialScale,

--- a/lib/src/photo_view_image_wrapper.dart
+++ b/lib/src/photo_view_image_wrapper.dart
@@ -13,7 +13,7 @@ class PhotoViewImageWrapper extends StatefulWidget {
     @required this.scaleBoundaries,
     @required this.imageProvider,
     @required this.size,
-    this.backgroundColor,
+    this.backgroundDecoration,
     this.gaplessPlayback = false,
     this.heroTag,
     this.enableRotation,
@@ -29,7 +29,7 @@ class PhotoViewImageWrapper extends StatefulWidget {
     @required this.scaleState,
     @required this.scaleBoundaries,
     @required this.size,
-    this.backgroundColor,
+    this.backgroundDecoration,
     this.heroTag,
     this.enableRotation,
   })  : imageProvider = null,
@@ -40,7 +40,7 @@ class PhotoViewImageWrapper extends StatefulWidget {
   final Function onStartPanning;
   final Size childSize;
   final PhotoViewScaleState scaleState;
-  final Color backgroundColor;
+  final Decoration backgroundDecoration;
   final ScaleBoundaries scaleBoundaries;
   final ImageProvider imageProvider;
   final bool gaplessPlayback;
@@ -306,7 +306,7 @@ class _PhotoViewImageWrapperState extends State<PhotoViewImageWrapper>
           transform: matrix,
           alignment: Alignment.center,
         )),
-        decoration: BoxDecoration(color: widget.backgroundColor),
+        decoration: widget.backgroundDecoration,
       ),
       onDoubleTap: computeNextScaleState,
       onScaleStart: onScaleStart,


### PR DESCRIPTION
This PR enables the user to provide a `Decoration` instead of a `Color` as background. In this way, the user can set gradients, images, patterns and colors as the background. 