### PR TITLE
Update photo_view_image_wrapper.dart

### DIFF
--- a/lib/src/photo_view_image_wrapper.dart
+++ b/lib/src/photo_view_image_wrapper.dart
@@ -135,6 +135,7 @@ class _PhotoViewImageWrapperState extends State<PhotoViewImageWrapper>
       animateScale(_scale, minScale);
       animatePosition(
           _position, clampPosition(_position * scaleComebackRatio, minScale));
+      widget.setNextScaleState(PhotoViewScaleState.initial);
       return;
     }
     // get magnitude from gesture velocity
@@ -270,12 +271,14 @@ class _PhotoViewImageWrapperState extends State<PhotoViewImageWrapper>
           widget.childSize, widget.scaleBoundaries);
     } while (prevScale == nextScale && _originalScaleState != _nextScaleState);
 
-    if (originalScale == nextScale) {
+    if (widget.scaleState == PhotoViewScaleState.covering && nextScale != 1.0
+        || originalScale == nextScale
+    ) {
+      widget.setNextScaleState(PhotoViewScaleState.initial);
       return;
+    } else {
+      widget.setNextScaleState(_nextScaleState);
     }
-
-    widget.setNextScaleState(_nextScaleState);
-  }
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
I love this lib but I've faced few bugs while using "PhotoVIewGallery" class. So basically I needed "PageView.builder" but with image scaling. While the image is scaled or is different from the original size the user can move around image but do not go to the next page. As soon as the image is back to it's original size the user can scroll between pages.

Issue 1:
When the minScale was set to the "PhotoViewComputedScale.contained" and user zoomed image out it went back to original size but didn't let user scroll between pages so I've fixed that.

Issue 2:
When the image size is too big it only scales it twice with the double tap and doesn't let user scroll between pages either so I've fixed that too. I'm pretty new to programming so open to any suggestions :)