### PR TITLE
move test package to dev_dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,11 +9,11 @@ environment:
 
 dependencies:
   after_layout: ^1.0.7
-  test: ^1.5.1
   flutter:
     sdk: flutter
 
 dev_dependencies:
+  test: ^1.5.1
   flutter_test:
     sdk: flutter
 


### PR DESCRIPTION
noticed that my `pubspec.lock` was injected with `csslib` `html` _packages_ and narrowed it down to your package. 
im not entirely sure how package `dependencies` and `dev_dependencies` relate to each other with dart and pub or how transitive dependencies get added. but i believe its best practice to only add direct dependencies to each package and what is used for `test` and `build script` as _dev_dependencies_.