### PR TITLE
Reset scale state to initial (and release lock) on minscale

### DIFF
--- a/lib/photo_view.dart
+++ b/lib/photo_view.dart
@@ -123,6 +123,7 @@ class PhotoView extends StatefulWidget {
     this.heroTag,
     this.scaleStateChangedCallback,
     this.enableRotation = false,
+    this.resetScaleStateOnMinScale = false,
   })  : child = null,
         childSize = null,
         super(key: key);
@@ -145,6 +146,7 @@ class PhotoView extends StatefulWidget {
     this.heroTag,
     this.scaleStateChangedCallback,
     this.enableRotation = false,
+    this.resetScaleStateOnMinScale = false,
   })  : loadingChild = null,
         imageProvider = null,
         gaplessPlayback = false,
@@ -199,6 +201,9 @@ class PhotoView extends StatefulWidget {
 
   /// The size of the custom [child]. [PhotoView] uses this value to compute the relation between the child and the container's size to calculate the scale value.
   final Size childSize;
+
+  /// Whether the scale state should be reset to initial if scale has reached the minScale value.
+  final bool resetScaleStateOnMinScale;
 
   @override
   State<StatefulWidget> createState() {
@@ -294,6 +299,7 @@ class _PhotoViewState extends State<PhotoView>
         size: _computedSize,
       ),
       heroTag: widget.heroTag,
+      resetScaleStateOnMinScale: widget.resetScaleStateOnMinScale,
     );
   }
 
@@ -341,6 +347,7 @@ class _PhotoViewState extends State<PhotoView>
         size: _computedSize,
       ),
       heroTag: widget.heroTag,
+      resetScaleStateOnMinScale: widget.resetScaleStateOnMinScale,
     );
   }
 

--- a/lib/photo_view_gallery.dart
+++ b/lib/photo_view_gallery.dart
@@ -54,6 +54,7 @@ class PhotoViewGallery extends StatefulWidget {
     this.scaleStateChangedCallback,
     this.enableRotation = false,
     this.defaultPageIndex = 0,
+    this.resetScaleStateOnMinScale = false,
   }) : super(key: key);
 
   /// A list of options to describe the items in the gallery
@@ -85,6 +86,9 @@ class PhotoViewGallery extends StatefulWidget {
 
   /// An index of the [PageView] inside [PhotoViewGallery]
   final int defaultPageIndex;
+
+  /// Mirror to [PhotoView.resetScaleStateOnMinScale]
+  final bool resetScaleStateOnMinScale;
 
   @override
   State<StatefulWidget> createState() {
@@ -143,6 +147,7 @@ class _PhotoViewGalleryState extends State<PhotoViewGallery> {
       heroTag: pageOption.heroTag,
       scaleStateChangedCallback: scaleStateChangedCallback,
       enableRotation: widget.enableRotation,
+      resetScaleStateOnMinScale: widget.resetScaleStateOnMinScale,
     );
   }
 }

--- a/lib/src/photo_view_image_wrapper.dart
+++ b/lib/src/photo_view_image_wrapper.dart
@@ -17,6 +17,7 @@ class PhotoViewImageWrapper extends StatefulWidget {
     this.gaplessPlayback = false,
     this.heroTag,
     this.enableRotation,
+    this.resetScaleStateOnMinScale = false,
   })  : customChild = null,
         super(key: key);
 
@@ -32,6 +33,7 @@ class PhotoViewImageWrapper extends StatefulWidget {
     this.backgroundDecoration,
     this.heroTag,
     this.enableRotation,
+    this.resetScaleStateOnMinScale = false,
   })  : imageProvider = null,
         gaplessPlayback = false,
         super(key: key);
@@ -48,6 +50,7 @@ class PhotoViewImageWrapper extends StatefulWidget {
   final String heroTag;
   final bool enableRotation;
   final Widget customChild;
+  final bool resetScaleStateOnMinScale;
 
   @override
   State<StatefulWidget> createState() {
@@ -78,6 +81,10 @@ class _PhotoViewImageWrapperState extends State<PhotoViewImageWrapper>
     setState(() {
       _scale = _scaleAnimation.value;
     });
+
+    if (_scaleAnimation.status == AnimationStatus.completed) {
+      _setScaleState();
+    }
   }
 
   void handlePositionAnimate() {
@@ -329,6 +336,14 @@ class _PhotoViewImageWrapperState extends State<PhotoViewImageWrapper>
             gaplessPlayback: widget.gaplessPlayback,
           )
         : widget.customChild;
+  }
+
+  void _setScaleState() {
+    final double minScale = widget.scaleBoundaries.computeMinScale();
+
+    if (widget.resetScaleStateOnMinScale && _scale <= minScale) {
+      widget.setNextScaleState(PhotoViewScaleState.initial);
+    }
   }
 }
 


### PR DESCRIPTION
Make it possible to reset scale state to initial (and release lock) when minScale has reached.

Possible fix for #60 #61 #62 


To keep it backwards compatible I have set the default value for ```resetScaleStateOnMinScale``` to false.