### PR TITLE
FIX: transitionOnUserGestures value not used 

### DIFF
--- a/lib/photo_view.dart
+++ b/lib/photo_view.dart
@@ -353,6 +353,7 @@ class _PhotoViewState extends State<PhotoView>
         size: _computedSize,
       ),
       heroTag: widget.heroTag,
+      transitionOnUserGestures: widget.transitionOnUserGestures,
     );
   }
 


### PR DESCRIPTION
The value set for `transitionOnUserGestures` was not passed to `PhotoViewImageWrapper`. This cause it to be always the default value of `false` regardless.