### PR TITLE
UNLOCK image if image is zoomedOut

### DIFF
--- a/example/lib/screens/examples/controller_example.dart
+++ b/example/lib/screens/examples/controller_example.dart
@@ -26,7 +26,7 @@ class _ControllerExampleState extends State<ControllerExample> {
     controller = PhotoViewController();
     controller
       ..scale = defScale
-      ..scaleState = PhotoViewScaleState.zooming
+      ..scaleState = PhotoViewScaleState.initial
       ..outputStateStream.listen(onControllerState);
     super.initState();
   }
@@ -112,7 +112,6 @@ class _ControllerExampleState extends State<ControllerExample> {
                 max: max,
                 onChanged: (double newRotation) {
                   controller.rotation = newRotation;
-                  controller.scaleState = PhotoViewScaleState.zooming;
                 })),
         Text(
           "Scale ${value.scale}",
@@ -127,7 +126,9 @@ class _ControllerExampleState extends State<ControllerExample> {
                 max: maxScale,
                 onChanged: (double newScale) {
                   controller.scale = newScale;
-                  controller.scaleState = PhotoViewScaleState.zooming;
+                  controller.scaleState = newScale > defScale
+                      ? PhotoViewScaleState.zoomedIn
+                      : PhotoViewScaleState.zoomedOut;
                 })),
       ],
     );

--- a/lib/photo_view.dart
+++ b/lib/photo_view.dart
@@ -448,7 +448,8 @@ PhotoViewScaleState defaultScaleStateCycle(PhotoViewScaleState actual) {
       return PhotoViewScaleState.originalSize;
     case PhotoViewScaleState.originalSize:
       return PhotoViewScaleState.initial;
-    case PhotoViewScaleState.zooming:
+    case PhotoViewScaleState.zoomedIn:
+    case PhotoViewScaleState.zoomedOut:
       return PhotoViewScaleState.initial;
     default:
       return PhotoViewScaleState.initial;

--- a/lib/photo_view.dart
+++ b/lib/photo_view.dart
@@ -299,7 +299,7 @@ class _PhotoViewState extends State<PhotoView>
       _controlledController = false;
       controller = widget.controller;
     }
-    controller.outputStateStream.listen(scaleStateListener);
+    controller.outputScaleStateStream.listen(scaleStateListener);
   }
 
   @override
@@ -341,9 +341,8 @@ class _PhotoViewState extends State<PhotoView>
     }
   }
 
-  void scaleStateListener(PhotoViewControllerValue value) {
-    if (widget.scaleStateChangedCallback != null &&
-        controller.scaleState != controller.prevValue.scaleState) {
+  void scaleStateListener(PhotoViewScaleState scaleState) {
+    if (widget.scaleStateChangedCallback != null) {
       widget.scaleStateChangedCallback(controller.scaleState);
     }
   }

--- a/lib/photo_view_gallery.dart
+++ b/lib/photo_view_gallery.dart
@@ -170,7 +170,10 @@ class _PhotoViewGalleryState extends State<PhotoViewGallery> {
 
   void scaleStateChangedCallback(PhotoViewScaleState scaleState) {
     setState(() {
-      _locked = scaleState != PhotoViewScaleState.initial;
+      _locked = (scaleState == PhotoViewScaleState.initial ||
+              scaleState == PhotoViewScaleState.zoomedOut)
+          ? false
+          : true;
     });
     if (widget.scaleStateChangedCallback != null) {
       widget.scaleStateChangedCallback(scaleState);

--- a/lib/src/photo_view_controller.dart
+++ b/lib/src/photo_view_controller.dart
@@ -41,7 +41,7 @@ abstract class PhotoViewControllerBase<T extends PhotoViewControllerValue> {
 
   /// The scale factor to transform the child (image or a customChild).
   ///
-  /// **Important**: Avoid setting this field without setting [scaleState] to [PhotoViewScaleState.zooming].
+  /// **Important**: Avoid setting this field without setting [scaleState] to [PhotoViewScaleState.zoomedIn] or [PhotoViewScaleState.zoomedOut].  <- this has to be chnaged in the future
   double scale;
 
   /// The rotation factor to transform the child (image or a customChild).
@@ -52,7 +52,8 @@ abstract class PhotoViewControllerBase<T extends PhotoViewControllerValue> {
 
   /// A way to represent the step of the "doubletap gesture cycle" in which PhotoView is.
   ///
-  /// **Important**: This fields is rarely externally set to a value different than [PhotoViewScaleState.zooming] after setting a [scale].
+  /// **Important**: This fields is rarely externally set to a value different than [PhotoViewScaleState.zoomedIn] or [PhotoViewScaleState.zoomedOut] after setting a [scale].
+  /// future TODO: setting the controller.scale should also set the scaleState to [PhotoViewScaleState.zoomedIn] or [PhotoViewScaleState.zoomedOut]
   PhotoViewScaleState scaleState;
 
   /// Update multiple fields of the state with only one update streamed.
@@ -184,6 +185,7 @@ class PhotoViewController
     if (value.scale == scale) {
       return;
     }
+
     prevValue = value;
     value = PhotoViewControllerValue(
         position: position,

--- a/lib/src/photo_view_image_wrapper.dart
+++ b/lib/src/photo_view_image_wrapper.dart
@@ -110,9 +110,17 @@ class _PhotoViewImageWrapperState extends State<PhotoViewImageWrapper>
   void onScaleUpdate(ScaleUpdateDetails details) {
     final double newScale = _scaleBefore * details.scale;
     final Offset delta = details.focalPoint - _normalizedPosition;
+
+    final double _scale =
+        widget.controller.scale ?? widget.scaleBoundaries.initialScale;
+    final double _initialScale = widget.scaleBoundaries.initialScale;
+
     final PhotoViewScaleState newScaleState = details.scale != 1.0
-        ? PhotoViewScaleState.zooming
+        ? (_scale > _initialScale)
+            ? PhotoViewScaleState.zoomedIn
+            : PhotoViewScaleState.zoomedOut
         : widget.controller.scaleState;
+
     widget.controller.updateMultiple(
         scaleState: newScaleState,
         scale: newScale,
@@ -249,7 +257,8 @@ class _PhotoViewImageWrapperState extends State<PhotoViewImageWrapper>
   void scaleStateListener(PhotoViewControllerValue value) {
     if (widget.controller.prevValue.scaleState !=
             widget.controller.scaleState &&
-        widget.controller.scaleState != PhotoViewScaleState.zooming) {
+        (widget.controller.scaleState != PhotoViewScaleState.zoomedIn &&
+            widget.controller.scaleState != PhotoViewScaleState.zoomedOut)) {
       final double prevScale = widget.controller.scale ??
           getScaleForScaleState(
               PhotoViewScaleState.initial, widget.scaleBoundaries);
@@ -267,11 +276,11 @@ class _PhotoViewImageWrapperState extends State<PhotoViewImageWrapper>
     final ScaleBoundaries scaleBoundaries = widget.scaleBoundaries;
     final PhotoViewControllerBase controller = widget.controller;
     final PhotoViewScaleState scaleState = controller.scaleState;
-    if (scaleState == PhotoViewScaleState.zooming) {
-      controller.scaleState = widget.scaleStateCycle(scaleState);
+    if (scaleState == PhotoViewScaleState.zoomedIn ||
+        scaleState == PhotoViewScaleState.zoomedOut) {
+      widget.controller.scaleState = widget.scaleStateCycle(scaleState);
       return;
     }
-
     final double originalScale =
         getScaleForScaleState(scaleState, scaleBoundaries);
 

--- a/lib/src/photo_view_image_wrapper.dart
+++ b/lib/src/photo_view_image_wrapper.dart
@@ -111,12 +111,10 @@ class _PhotoViewImageWrapperState extends State<PhotoViewImageWrapper>
     final double newScale = _scaleBefore * details.scale;
     final Offset delta = details.focalPoint - _normalizedPosition;
 
-    final double _scale =
-        widget.controller.scale ?? widget.scaleBoundaries.initialScale;
     final double _initialScale = widget.scaleBoundaries.initialScale;
 
     final PhotoViewScaleState newScaleState = details.scale != 1.0
-        ? (_scale > _initialScale)
+        ? (newScale > _initialScale)
             ? PhotoViewScaleState.zoomedIn
             : PhotoViewScaleState.zoomedOut
         : widget.controller.scaleState;

--- a/lib/src/photo_view_scale_state.dart
+++ b/lib/src/photo_view_scale_state.dart
@@ -1,2 +1,9 @@
 /// A way to represent the step of the "doubletap gesture cycle" in which PhotoView is.
-enum PhotoViewScaleState { initial, covering, originalSize, zooming, zoomedIn, zoomedOut} // 'zooming' will get unnecessary
+enum PhotoViewScaleState {
+  initial,
+  covering,
+  originalSize,
+  zooming,
+  zoomedIn,
+  zoomedOut
+} // 'zooming' will get unnecessary

--- a/lib/src/photo_view_scale_state.dart
+++ b/lib/src/photo_view_scale_state.dart
@@ -1,2 +1,2 @@
 /// A way to represent the step of the "doubletap gesture cycle" in which PhotoView is.
-enum PhotoViewScaleState { initial, covering, originalSize, zooming }
+enum PhotoViewScaleState { initial, covering, originalSize, zooming, zoomedIn, zoomedOut} // 'zooming' will get unnecessary

--- a/lib/src/photo_view_scale_state.dart
+++ b/lib/src/photo_view_scale_state.dart
@@ -3,7 +3,6 @@ enum PhotoViewScaleState {
   initial,
   covering,
   originalSize,
-  zooming,
   zoomedIn,
   zoomedOut
-} // 'zooming' will get unnecessary
+}

--- a/lib/src/photo_view_utils.dart
+++ b/lib/src/photo_view_utils.dart
@@ -7,7 +7,8 @@ double getScaleForScaleState(
     PhotoViewScaleState scaleState, ScaleBoundaries scaleBoundaries) {
   switch (scaleState) {
     case PhotoViewScaleState.initial:
-    case PhotoViewScaleState.zooming:
+    case PhotoViewScaleState.zoomedIn:
+    case PhotoViewScaleState.zoomedOut:
       return _clampSize(scaleBoundaries.initialScale, scaleBoundaries);
     case PhotoViewScaleState.covering:
       return _clampSize(

--- a/test/controller_test.dart
+++ b/test/controller_test.dart
@@ -38,8 +38,11 @@ void main() {
     controller.rotationFocusPoint = Offset.zero;
     expect(controller.rotationFocusPoint, Offset.zero);
 
-    controller.scaleState = PhotoViewScaleState.zooming;
-    expect(controller.scaleState, PhotoViewScaleState.zooming);
+    controller.scaleState = PhotoViewScaleState.zoomedIn;
+    expect(controller.scaleState, PhotoViewScaleState.zoomedIn);
+
+    // controller.scaleState = PhotoViewScaleState.zoomedOut;
+    // expect(controller.scaleState, PhotoViewScaleState.zoomedOut);
 
     controller.updateMultiple(
         position: const Offset(1, 1), scaleState: PhotoViewScaleState.initial);
@@ -63,35 +66,36 @@ void main() {
         scale: null,
         rotation: 0.0,
         rotationFocusPoint: null,
-        scaleState: PhotoViewScaleState.zooming);
+        scaleState: PhotoViewScaleState.zoomedOut);
 
     const PhotoViewControllerValue value2 = const PhotoViewControllerValue(
         position: Offset.zero,
         scale: null,
         rotation: 1.0,
         rotationFocusPoint: null,
-        scaleState: PhotoViewScaleState.zooming);
+        scaleState: PhotoViewScaleState.zoomedOut);
 
     const PhotoViewControllerValue value3 = const PhotoViewControllerValue(
         position: Offset.zero,
         scale: 3.0,
         rotation: 1.0,
         rotationFocusPoint: null,
-        scaleState: PhotoViewScaleState.zooming);
+        scaleState: PhotoViewScaleState.zoomedOut);
 
     const PhotoViewControllerValue value4 = const PhotoViewControllerValue(
         position: const Offset(1, 1),
         scale: 3.0,
         rotation: 45.0,
         rotationFocusPoint: null,
-        scaleState: PhotoViewScaleState.zooming);
+        scaleState: PhotoViewScaleState.zoomedOut);
 
     expect(controller.outputStateStream,
         emitsInOrder([value1, value2, value3, value4]));
-    controller.scaleState = PhotoViewScaleState.zooming;
+    controller.scaleState = PhotoViewScaleState.zoomedOut;
     controller.rotation = 1.0;
     controller.scale = 3.0;
 
     controller.updateMultiple(position: const Offset(1, 1), rotation: 45.0);
+    //Testing with 'zoomedIn' and 'zoomedOut' will be diffcult as long as scaleState isn't changed in the controller's scale setter
   });
 }


### PR DESCRIPTION
GREAT REPO! 👍 

I have added two more scaleStates: '**zoomedIn**' and '**zoomedOut**'.
The trigger between those two states is currently the **initialScale**:

_zoomedOut **<=** initialScale **<** zoomedIn_
_zoomedOut_ -> **unlocks** the image
_zoomedIn_ -> **locks** the image

The (default)StateCycle stays the same.
**However, the scaleState 'zooming' becomes unnecessary.**

I've encountered some performance issues, so I've implemented a new stream that will fire **ONLY** if a scaleState change is detected.

At this point, the additional customization of the trigger point will be EASY :)

i guess this will fix #105 
and is at least an approach for #41 