### PR TITLE
Fix FlutterError breaking changes

### DIFF
--- a/lib/src/photo_view_utils.dart
+++ b/lib/src/photo_view_utils.dart
@@ -1,8 +1,8 @@
 import 'dart:math' as math;
 import 'dart:ui';
 
-import 'package:flutter/widgets.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
 import 'package:photo_view/photo_view.dart';
 
 double getScaleForScaleState(
@@ -118,8 +118,13 @@ class IgnorableChangeNotifier extends ChangeNotifier {
   bool _debugAssertNotDisposed() {
     assert(() {
       if (_ignorableListeners == null) {
-        throw FlutterError('A $runtimeType was used after being disposed.\n'
-            'Once you have called dispose() on a $runtimeType, it can no longer be used.');
+        throw FlutterError.fromParts(
+          <DiagnosticsNode>[
+            ErrorSummary('A $runtimeType was used after being disposed.'),
+            ErrorDescription(
+                'Once you have called dispose() on a $runtimeType, it can no longer be used.'),
+          ],
+        );
       }
       return true;
     }());
@@ -162,16 +167,19 @@ class IgnorableChangeNotifier extends ChangeNotifier {
             listener();
           }
         } catch (exception, stack) {
-          FlutterError.reportError(FlutterErrorDetails(
-            exception: exception,
-            stack: stack,
-            library: 'Photoview library',
-            context: 'while dispatching notifications for $runtimeType',
-            informationCollector: (StringBuffer information) {
-              information.writeln('The $runtimeType sending notification was:');
-              information.write('  $this');
-            },
-          ));
+          FlutterError.reportError(
+            FlutterErrorDetails(
+              exception: exception,
+              stack: stack,
+              library: 'Photoview library',
+              context: ErrorDescription(
+                  'while dispatching notifications for $runtimeType'),
+              informationCollector: () sync* {
+                yield DiagnosticsProperty<IgnorableChangeNotifier>(
+                    '$runtimeType sending notification', this);
+              },
+            ),
+          );
         }
       }
     }
@@ -193,6 +201,7 @@ class IgnorableValueNotifier<T> extends IgnorableChangeNotifier
   @override
   T get value => _value;
   T _value;
+
   set value(T newValue) {
     if (_value == newValue) {
       return;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.2.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -220,7 +220,7 @@ packages:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.3"
   shelf:
     dependency: transitive
     description:
@@ -309,21 +309,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.1"
+    version: "1.6.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.4"
+    version: "0.2.5"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.3"
+    version: "0.2.5"
   typed_data:
     dependency: transitive
     description:
@@ -368,3 +368,4 @@ packages:
     version: "2.1.15"
 sdks:
   dart: ">=2.2.0 <3.0.0"
+  flutter: ">=1.5.9-pre.94 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,8 @@ author: Renan C. Araújo <renan@caraujo.me>
 homepage: https://github.com/renancaraujo/photo_view
 
 environment:
-  sdk: ">=2.0.0 <3.0.0"
+  sdk: ">=2.2.0 <3.0.0"
+  flutter: ">=1.5.9-pre.94 <2.0.0"
 
 dependencies:
   after_layout: ^1.0.7


### PR DESCRIPTION
Flutter `1.5.9-pre.94` on the master channel introduced  breaking changes in `FlutterError`, `FlutterErrorDetails` and `InformationCollector` (flutter/flutter#30983) which broke `photo_view` and a lot of other packages (flutter/flutter#31962). This commit fixes the issue for `photo_view`.

Fixes #135 