### PR TITLE
Fixes compatibility with Flutter 1.6.0 (current master channel)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.4.0
+
+- **BREAKING CHANGE**: Only compatible with Flutter 1.6.0+. Updated rgd. changes
+  in the ImageStreamListener APIs.
+- Updated Gradle infrastructure.
+
 # CHANGELOG
 
 See the [releases page on github](https://github.com/renancaraujo/photo_view/releases)

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.4.1'
     }
 }
 

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/lib/photo_view.dart
+++ b/lib/photo_view.dart
@@ -365,7 +365,9 @@ class _PhotoViewState extends State<PhotoView>
     final Completer completer = Completer<ImageInfo>();
     final ImageStream stream =
         widget.imageProvider.resolve(const ImageConfiguration());
-    final listener = (ImageInfo info, bool synchronousCall) {
+
+    final ImageStreamListener listener =
+        ImageStreamListener((ImageInfo info, bool synchronousCall) {
       if (!completer.isCompleted) {
         completer.complete(info);
         if (mounted) {
@@ -376,7 +378,7 @@ class _PhotoViewState extends State<PhotoView>
           });
         }
       }
-    };
+    });
     stream.addListener(listener);
     completer.future.then((_) {
       stream.removeListener(listener);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -368,4 +368,4 @@ packages:
     version: "2.1.15"
 sdks:
   dart: ">=2.2.0 <3.0.0"
-  flutter: ">=1.4.7 <2.0.0"
+  flutter: ">=1.5.9-pre.94 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: photo_view
-description: Photo View provides a gesture sensitive zoomable widget. PhotoView is largely used to show interacive images.
-version: 0.3.3
+description: Photo View provides a gesture sensitive zoomable widget. PhotoView is largely used to show interactive images.
+version: 0.4.0
 author: Renan C. Araújo <renan@caraujo.me>
 homepage: https://github.com/renancaraujo/photo_view
 
 environment:
   sdk: ">=2.2.0 <3.0.0"
-  flutter: ">=1.4.7 <2.0.0"
+  flutter: ">=1.5.9-pre.94 <2.0.0"
 
 dependencies:
   after_layout: ^1.0.7


### PR DESCRIPTION
This is a breaking change which is not compatible with flutter versions <1.6.0. 
Library users are advised to either upgrade to `1.6.0` (and use `0.4.0` of `photo_view`) or stay with `0.3.3` of this package.

Fixes #144 