### PR TITLE
Change listener after the breaking change of ImageStreamListener

### DIFF
--- a/lib/photo_view.dart
+++ b/lib/photo_view.dart
@@ -349,8 +349,7 @@ class PhotoView extends StatefulWidget {
   }
 }
 
-class _PhotoViewState extends State<PhotoView>
-    with AfterLayoutMixin<PhotoView> {
+class _PhotoViewState extends State<PhotoView> with AfterLayoutMixin<PhotoView> {
   bool _loading;
   Size _childSize;
   Size _outerSize;
@@ -363,21 +362,18 @@ class _PhotoViewState extends State<PhotoView>
 
   Future<ImageInfo> _getImage() {
     final Completer completer = Completer<ImageInfo>();
-    final ImageStream stream =
-        widget.imageProvider.resolve(const ImageConfiguration());
-    final listener =
-        ImageStreamListener((ImageInfo info, bool synchronousCall) {
+    final ImageStream stream = widget.imageProvider.resolve(const ImageConfiguration());
+    final listener = (ImageInfo info, bool synchronousCall) {
       if (!completer.isCompleted) {
         completer.complete(info);
         if (mounted) {
           setState(() {
-            _childSize =
-                Size(info.image.width.toDouble(), info.image.height.toDouble());
+            _childSize = Size(info.image.width.toDouble(), info.image.height.toDouble());
             _loading = false;
           });
         }
       }
-    });
+    };
     stream.addListener(listener);
     completer.future.then((_) {
       stream.removeListener(listener);
@@ -473,9 +469,7 @@ class _PhotoViewState extends State<PhotoView>
 
   @override
   Widget build(BuildContext context) {
-    return widget.child == null
-        ? _buildImage(context)
-        : _buildCustomChild(context);
+    return widget.child == null ? _buildImage(context) : _buildCustomChild(context);
   }
 
   Widget _buildCustomChild(BuildContext context) {
@@ -503,9 +497,7 @@ class _PhotoViewState extends State<PhotoView>
   }
 
   Widget _buildImage(BuildContext context) {
-    return widget.heroTag == null
-        ? _buildWithFuture(context)
-        : _buildSync(context);
+    return widget.heroTag == null ? _buildWithFuture(context) : _buildSync(context);
   }
 
   Widget _buildWithFuture(BuildContext context) {
@@ -565,8 +557,7 @@ class _PhotoViewState extends State<PhotoView>
           );
   }
 
-  Size get _computedOuterSize =>
-      widget.customSize ?? _outerSize ?? MediaQuery.of(context).size;
+  Size get _computedOuterSize => widget.customSize ?? _outerSize ?? MediaQuery.of(context).size;
 }
 
 /// The default [ScaleStateCycle]

--- a/lib/photo_view.dart
+++ b/lib/photo_view.dart
@@ -349,7 +349,8 @@ class PhotoView extends StatefulWidget {
   }
 }
 
-class _PhotoViewState extends State<PhotoView> with AfterLayoutMixin<PhotoView> {
+class _PhotoViewState extends State<PhotoView>
+    with AfterLayoutMixin<PhotoView> {
   bool _loading;
   Size _childSize;
   Size _outerSize;
@@ -362,13 +363,15 @@ class _PhotoViewState extends State<PhotoView> with AfterLayoutMixin<PhotoView> 
 
   Future<ImageInfo> _getImage() {
     final Completer completer = Completer<ImageInfo>();
-    final ImageStream stream = widget.imageProvider.resolve(const ImageConfiguration());
+    final ImageStream stream =
+        widget.imageProvider.resolve(const ImageConfiguration());
     final listener = (ImageInfo info, bool synchronousCall) {
       if (!completer.isCompleted) {
         completer.complete(info);
         if (mounted) {
           setState(() {
-            _childSize = Size(info.image.width.toDouble(), info.image.height.toDouble());
+            _childSize =
+                Size(info.image.width.toDouble(), info.image.height.toDouble());
             _loading = false;
           });
         }
@@ -469,7 +472,9 @@ class _PhotoViewState extends State<PhotoView> with AfterLayoutMixin<PhotoView> 
 
   @override
   Widget build(BuildContext context) {
-    return widget.child == null ? _buildImage(context) : _buildCustomChild(context);
+    return widget.child == null
+        ? _buildImage(context)
+        : _buildCustomChild(context);
   }
 
   Widget _buildCustomChild(BuildContext context) {
@@ -497,7 +502,9 @@ class _PhotoViewState extends State<PhotoView> with AfterLayoutMixin<PhotoView> 
   }
 
   Widget _buildImage(BuildContext context) {
-    return widget.heroTag == null ? _buildWithFuture(context) : _buildSync(context);
+    return widget.heroTag == null
+        ? _buildWithFuture(context)
+        : _buildSync(context);
   }
 
   Widget _buildWithFuture(BuildContext context) {
@@ -557,7 +564,8 @@ class _PhotoViewState extends State<PhotoView> with AfterLayoutMixin<PhotoView> 
           );
   }
 
-  Size get _computedOuterSize => widget.customSize ?? _outerSize ?? MediaQuery.of(context).size;
+  Size get _computedOuterSize =>
+      widget.customSize ?? _outerSize ?? MediaQuery.of(context).size;
 }
 
 /// The default [ScaleStateCycle]

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "2.1.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -234,7 +234,7 @@ packages:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.2"
   shelf:
     dependency: transitive
     description:
@@ -323,21 +323,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.3"
+    version: "1.6.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.5"
+    version: "0.2.4"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.5"
+    version: "0.2.3"
   typed_data:
     dependency: transitive
     description:
@@ -382,4 +382,3 @@ packages:
     version: "2.1.15"
 sdks:
   dart: ">=2.2.0 <3.0.0"
-  flutter: ">=1.5.9-pre.94 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,6 @@ homepage: https://github.com/renancaraujo/photo_view
 
 environment:
   sdk: ">=2.2.0 <3.0.0"
-  flutter: ">=1.5.9-pre.94 <2.0.0"
 
 dependencies:
   after_layout: ^1.0.7


### PR DESCRIPTION
After the breaking change in [v1.6.2](https://github.com/flutter/flutter/pull/32936/commits/40da9f5f31b1ea8e7a712429141be617d9eba13d)
I see that this package only available for Flutter version which is lower than that version.

This pull request changed the listener (ImageStreamListener) to match with the breaking change, so this package can be available for v1.6.2 and higher.