### PR TITLE
Add recalc scale behavior

### DIFF
--- a/lib/src/controller/photo_view_controller_delegate.dart
+++ b/lib/src/controller/photo_view_controller_delegate.dart
@@ -14,8 +14,10 @@ import 'package:photo_view/src/utils/photo_view_utils.dart';
 import 'package:photo_view/src/controller/photo_view_controller.dart';
 import 'package:photo_view/src/controller/photo_view_scalestate_controller.dart';
 
-
 /// A  class to hold internal layout logic to sync both controller states
+///
+/// It reacts to layout changes (eg: enter landscape or widget resize) and syncs the two controllers.
+/// It is responsible
 mixin PhotoViewControllerDelegate on State<PhotoViewCore> {
   PhotoViewControllerBase get controller => widget.controller;
 
@@ -80,7 +82,8 @@ mixin PhotoViewControllerDelegate on State<PhotoViewCore> {
   Offset get position => controller.position;
 
   double get scale {
-    if(markNeedsScaleRecalc && !isScaleStateZooming(scaleStateController.scaleState)){
+    if (markNeedsScaleRecalc &&
+        !isScaleStateZooming(scaleStateController.scaleState)) {
       scale = getScaleForScaleState(
         scaleStateController.scaleState,
         scaleBoundaries,

--- a/lib/src/controller/photo_view_controller_delegate.dart
+++ b/lib/src/controller/photo_view_controller_delegate.dart
@@ -9,9 +9,11 @@ import 'package:photo_view/photo_view.dart'
         PhotoViewScaleStateController,
         ScaleStateCycle;
 import 'package:photo_view/src/core/photo_view_core.dart';
+import 'package:photo_view/src/photo_view_scale_state.dart';
 import 'package:photo_view/src/utils/photo_view_utils.dart';
 import 'package:photo_view/src/controller/photo_view_controller.dart';
 import 'package:photo_view/src/controller/photo_view_scalestate_controller.dart';
+
 
 /// A  class to hold internal layout logic to sync both controller states
 mixin PhotoViewControllerDelegate on State<PhotoViewCore> {
@@ -26,6 +28,9 @@ mixin PhotoViewControllerDelegate on State<PhotoViewCore> {
 
   Alignment get basePosition => widget.basePosition;
   Function(double prevScale, double nextScale) _animateScale;
+
+  /// Mark if scale need recalculation, useful for scale boundaries changes.
+  bool markNeedsScaleRecalc = true;
 
   void startListeners() {
     controller.addIgnorableListener(_blindScaleListener);
@@ -74,12 +79,16 @@ mixin PhotoViewControllerDelegate on State<PhotoViewCore> {
 
   Offset get position => controller.position;
 
-  double get scale =>
-      controller.scale ??
-      getScaleForScaleState(
+  double get scale {
+    if(markNeedsScaleRecalc && !isScaleStateZooming(scaleStateController.scaleState)){
+      scale = getScaleForScaleState(
         scaleStateController.scaleState,
         scaleBoundaries,
       );
+      markNeedsScaleRecalc = false;
+    }
+    return controller.scale;
+  }
 
   set scale(double scale) => controller.setScaleInvisibly(scale);
 

--- a/lib/src/core/photo_view_core.dart
+++ b/lib/src/core/photo_view_core.dart
@@ -259,11 +259,10 @@ class PhotoViewCoreState extends State<PhotoViewCore>
 
   @override
   Widget build(BuildContext context) {
-    if(widget.scaleBoundaries != cachedScaleBoundaries){
+    if (widget.scaleBoundaries != cachedScaleBoundaries) {
       markNeedsScaleRecalc = true;
       cachedScaleBoundaries = widget.scaleBoundaries;
     }
-
 
     return StreamBuilder(
         stream: controller.outputStateStream,

--- a/lib/src/core/photo_view_core.dart
+++ b/lib/src/core/photo_view_core.dart
@@ -97,6 +97,8 @@ class PhotoViewCoreState extends State<PhotoViewCore>
 
   PhotoViewHeroAttributes get heroAttributes => widget.heroAttributes;
 
+  ScaleBoundaries cachedScaleBoundaries;
+
   void handleScaleAnimation() {
     scale = _scaleAnimation.value;
   }
@@ -228,6 +230,8 @@ class PhotoViewCoreState extends State<PhotoViewCore>
       ..addListener(handleRotationAnimation);
     startListeners();
     addAnimateOnScaleStateUpdate(animateOnScaleStateUpdate);
+
+    cachedScaleBoundaries = widget.scaleBoundaries;
   }
 
   void animateOnScaleStateUpdate(double prevScale, double nextScale) {
@@ -255,6 +259,12 @@ class PhotoViewCoreState extends State<PhotoViewCore>
 
   @override
   Widget build(BuildContext context) {
+    if(widget.scaleBoundaries != cachedScaleBoundaries){
+      markNeedsScaleRecalc = true;
+      cachedScaleBoundaries = widget.scaleBoundaries;
+    }
+
+
     return StreamBuilder(
         stream: controller.outputStateStream,
         initialData: controller.prevValue,

--- a/lib/src/photo_view_scale_state.dart
+++ b/lib/src/photo_view_scale_state.dart
@@ -6,3 +6,8 @@ enum PhotoViewScaleState {
   zoomedIn,
   zoomedOut,
 }
+
+// Todo: change for extension when they arrive
+bool isScaleStateZooming(PhotoViewScaleState scaleState) {
+  return scaleState == PhotoViewScaleState.zoomedIn || scaleState == PhotoViewScaleState.zoomedOut;
+}

--- a/lib/src/photo_view_scale_state.dart
+++ b/lib/src/photo_view_scale_state.dart
@@ -9,5 +9,6 @@ enum PhotoViewScaleState {
 
 // Todo: change for extension when they arrive
 bool isScaleStateZooming(PhotoViewScaleState scaleState) {
-  return scaleState == PhotoViewScaleState.zoomedIn || scaleState == PhotoViewScaleState.zoomedOut;
+  return scaleState == PhotoViewScaleState.zoomedIn ||
+      scaleState == PhotoViewScaleState.zoomedOut;
 }

--- a/lib/src/utils/photo_view_utils.dart
+++ b/lib/src/utils/photo_view_utils.dart
@@ -86,6 +86,26 @@ class ScaleBoundaries {
     }
     return _initialScale.clamp(minScale, maxScale);
   }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+          other is ScaleBoundaries &&
+              runtimeType == other.runtimeType &&
+              _minScale == other._minScale &&
+              _maxScale == other._maxScale &&
+              _initialScale == other._initialScale &&
+              outerSize == other.outerSize &&
+              childSize == other.childSize;
+
+  @override
+  int get hashCode =>
+      _minScale.hashCode ^
+      _maxScale.hashCode ^
+      _initialScale.hashCode ^
+      outerSize.hashCode ^
+      childSize.hashCode;
+
 }
 
 double _scaleForContained(Size size, Size childSize) {

--- a/lib/src/utils/photo_view_utils.dart
+++ b/lib/src/utils/photo_view_utils.dart
@@ -4,7 +4,7 @@ import 'dart:ui' show Size;
 import "package:photo_view/src/photo_view_computed_scale.dart";
 import 'package:photo_view/src/photo_view_scale_state.dart';
 
-// Given a [PhotoViewScaleState], returns a
+/// Given a [PhotoViewScaleState], returns a scale value considering scaleBoundaries.
 double getScaleForScaleState(
   PhotoViewScaleState scaleState,
   ScaleBoundaries scaleBoundaries,
@@ -26,6 +26,8 @@ double getScaleForScaleState(
   }
 }
 
+/// Internal class to wraps custom scale boundaries (min, max and initial)
+/// Also, stores values regarding the two sizes: the container and teh child.
 class ScaleBoundaries {
   const ScaleBoundaries(
     this._minScale,
@@ -131,6 +133,7 @@ double _clampSize(double size, ScaleBoundaries scaleBoundaries) {
   return size.clamp(scaleBoundaries.minScale, scaleBoundaries.maxScale);
 }
 
+/// Simple class to store a min and a max value
 class CornersRange {
   const CornersRange(this.min, this.max);
   final double min;

--- a/lib/src/utils/photo_view_utils.dart
+++ b/lib/src/utils/photo_view_utils.dart
@@ -90,13 +90,13 @@ class ScaleBoundaries {
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is ScaleBoundaries &&
-              runtimeType == other.runtimeType &&
-              _minScale == other._minScale &&
-              _maxScale == other._maxScale &&
-              _initialScale == other._initialScale &&
-              outerSize == other.outerSize &&
-              childSize == other.childSize;
+      other is ScaleBoundaries &&
+          runtimeType == other.runtimeType &&
+          _minScale == other._minScale &&
+          _maxScale == other._maxScale &&
+          _initialScale == other._initialScale &&
+          outerSize == other.outerSize &&
+          childSize == other.childSize;
 
   @override
   int get hashCode =>
@@ -105,7 +105,6 @@ class ScaleBoundaries {
       _initialScale.hashCode ^
       outerSize.hashCode ^
       childSize.hashCode;
-
 }
 
 double _scaleForContained(Size size, Size childSize) {


### PR DESCRIPTION
Ref: #163

In this PR:

We cache the rendered `ScaleBoundary` into the core's state. If we build a different one, we mark the delegate to recalc the scale from the `scaleState` only if the user is not zooming (in or out).