### PR TITLE
Add filterQuality property to improve image quality after scale

### DIFF
--- a/example/lib/screens/examples/full_screen_examples.dart
+++ b/example/lib/screens/examples/full_screen_examples.dart
@@ -31,6 +31,21 @@ class FullScreenExamples extends StatelessWidget {
                   },
                 ),
                 ExampleButtonNode(
+                  title: "Large Image (filter quality: medium)",
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => const FullScreenWrapper(
+                          imageProvider:
+                              const AssetImage("assets/large-image.jpg"),
+                          filterQuality: FilterQuality.medium,
+                        ),
+                      ),
+                    );
+                  },
+                ),
+                ExampleButtonNode(
                   title: "Small Image (custom background)",
                   onPressed: () {
                     Navigator.push(
@@ -200,6 +215,7 @@ class FullScreenWrapper extends StatelessWidget {
     this.maxScale,
     this.initialScale,
     this.basePosition = Alignment.center,
+    this.filterQuality = FilterQuality.none,
   });
 
   final ImageProvider imageProvider;
@@ -209,6 +225,7 @@ class FullScreenWrapper extends StatelessWidget {
   final dynamic maxScale;
   final dynamic initialScale;
   final Alignment basePosition;
+  final FilterQuality filterQuality;
 
   @override
   Widget build(BuildContext context) {
@@ -224,6 +241,7 @@ class FullScreenWrapper extends StatelessWidget {
         maxScale: maxScale,
         initialScale: initialScale,
         basePosition: basePosition,
+        filterQuality: filterQuality,
       ),
     );
   }

--- a/lib/photo_view.dart
+++ b/lib/photo_view.dart
@@ -244,6 +244,7 @@ class PhotoView extends StatefulWidget {
     this.customSize,
     this.gestureDetectorBehavior,
     this.tightMode,
+    this.filterQuality,
   })  : child = null,
         childSize = null,
         super(key: key);
@@ -274,6 +275,7 @@ class PhotoView extends StatefulWidget {
     this.customSize,
     this.gestureDetectorBehavior,
     this.tightMode,
+    this.filterQuality,
   })  : loadingChild = null,
         imageProvider = null,
         gaplessPlayback = false,
@@ -356,6 +358,9 @@ class PhotoView extends StatefulWidget {
   /// Enables tight mode, making background container assume the size of the image/child.
   /// Useful when inside a [Dialog]
   final bool tightMode;
+
+  /// Quality levels for image filters.
+  final FilterQuality filterQuality;
 
   @override
   State<StatefulWidget> createState() {
@@ -516,6 +521,7 @@ class _PhotoViewState extends State<PhotoView> {
       onTapDown: widget.onTapDown,
       gestureDetectorBehavior: widget.gestureDetectorBehavior,
       tightMode: widget.tightMode ?? false,
+      filterQuality: widget.filterQuality ?? FilterQuality.none,
     );
   }
 
@@ -570,6 +576,7 @@ class _PhotoViewState extends State<PhotoView> {
       onTapDown: widget.onTapDown,
       gestureDetectorBehavior: widget.gestureDetectorBehavior,
       tightMode: widget.tightMode ?? false,
+      filterQuality: widget.filterQuality ?? FilterQuality.none,
     );
   }
 

--- a/lib/photo_view_gallery.dart
+++ b/lib/photo_view_gallery.dart
@@ -237,6 +237,7 @@ class _PhotoViewGalleryState extends State<PhotoViewGallery> {
             onTapDown: pageOption.onTapDown,
             gestureDetectorBehavior: pageOption.gestureDetectorBehavior,
             tightMode: pageOption.tightMode,
+            filterQuality: pageOption.filterQuality,
           )
         : PhotoView(
             key: ObjectKey(index),
@@ -258,6 +259,7 @@ class _PhotoViewGalleryState extends State<PhotoViewGallery> {
             onTapDown: pageOption.onTapDown,
             gestureDetectorBehavior: pageOption.gestureDetectorBehavior,
             tightMode: pageOption.tightMode,
+            filterQuality: pageOption.filterQuality,
           );
 
     return ClipRect(
@@ -294,6 +296,7 @@ class PhotoViewGalleryPageOptions {
     this.onTapDown,
     this.gestureDetectorBehavior,
     this.tightMode,
+    this.filterQuality,
   })  : child = null,
         childSize = null,
         assert(imageProvider != null);
@@ -313,6 +316,7 @@ class PhotoViewGalleryPageOptions {
     this.onTapDown,
     this.gestureDetectorBehavior,
     this.tightMode,
+    this.filterQuality,
   })  : imageProvider = null,
         assert(child != null),
         assert(childSize != null);
@@ -361,4 +365,7 @@ class PhotoViewGalleryPageOptions {
 
   /// Mirror to [PhotoView.tightMode]
   final bool tightMode;
+
+  /// Quality levels for image filters.
+  final FilterQuality filterQuality;
 }


### PR DESCRIPTION
## Before
![1](https://user-images.githubusercontent.com/691621/70616278-0af15580-1c49-11ea-9d30-eb77b5fe2725.png)

## After (FilterQuality.medium)
![2](https://user-images.githubusercontent.com/691621/70616335-28262400-1c49-11ea-8907-aeed18f5c36b.png)

```dart
@override
Widget build(BuildContext context) {
  return Container(
    child: PhotoView(
      imageProvider: AssetImage("assets/large-image.jpg"),
      filterQuality: FilterQuality.medium,
    )
  );
}
```