### PR TITLE
Updating usage of InheritedWidget due to Flutter SDK v1.12.1 

### DIFF
--- a/lib/src/core/photo_view_gesture_detector.dart
+++ b/lib/src/core/photo_view_gesture_detector.dart
@@ -181,8 +181,8 @@ class PhotoViewGestureDetectorScope extends InheritedWidget {
   }) : super(child: child);
 
   static PhotoViewGestureDetectorScope of(BuildContext context) {
-    final PhotoViewGestureDetectorScope scope =
-        context.inheritFromWidgetOfExactType(PhotoViewGestureDetectorScope);
+    final PhotoViewGestureDetectorScope scope = context
+        .dependOnInheritedWidgetOfExactType<PhotoViewGestureDetectorScope>();
     return scope;
   }
 


### PR DESCRIPTION
Avoiding context.inheritFromWidgetOfExactType and using context.dependOnInheritedWidgetOfExactType