### PR TITLE
Prevent manual rotation being passed to output stream when not enabled

### DIFF
--- a/lib/src/controller/photo_view_controller.dart
+++ b/lib/src/controller/photo_view_controller.dart
@@ -93,7 +93,6 @@ class PhotoViewControllerValue {
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is PhotoViewControllerValue &&
-          runtimeType == other.runtimeType &&
           position == other.position &&
           scale == other.scale &&
           rotation == other.rotation &&
@@ -110,6 +109,18 @@ class PhotoViewControllerValue {
   String toString() {
     return 'PhotoViewControllerValue{position: $position, scale: $scale, rotation: $rotation, rotationFocusPoint: $rotationFocusPoint}';
   }
+}
+
+/// The state value stored and streamed by [PhotoViewController] when a rotation is
+/// is explicitly applied, even if PhotoViewController.enabledRotation is not enabled.
+@immutable
+class PhotoViewControllerExplicitValue extends PhotoViewControllerValue {
+  const PhotoViewControllerExplicitValue({
+    @required Offset position,
+    @required double scale,
+    @required double rotation,
+    @required Offset rotationFocusPoint,
+  }) : super(position: position, scale: scale, rotation: rotation, rotationFocusPoint: rotationFocusPoint);
 }
 
 /// The default implementation of [PhotoViewControllerBase].
@@ -234,7 +245,7 @@ class PhotoViewController
       return;
     }
     prevValue = value;
-    value = PhotoViewControllerValue(
+    value = PhotoViewControllerExplicitValue(
       position: position,
       scale: scale,
       rotation: rotation,

--- a/lib/src/core/photo_view_core.dart
+++ b/lib/src/core/photo_view_core.dart
@@ -141,8 +141,8 @@ class PhotoViewCoreState extends State<PhotoViewCore>
     updateMultiple(
       scale: newScale,
       position: clampPosition(position: delta * details.scale),
-      rotation: _rotationBefore + details.rotation,
-      rotationFocusPoint: details.focalPoint,
+      rotation: widget.enableRotation ? _rotationBefore + details.rotation : null,
+      rotationFocusPoint: widget.enableRotation ? details.focalPoint : null,
     );
   }
 

--- a/lib/src/core/photo_view_core.dart
+++ b/lib/src/core/photo_view_core.dart
@@ -293,7 +293,7 @@ class PhotoViewCoreState extends State<PhotoViewCore>
             final matrix = Matrix4.identity()
               ..translate(value.position.dx, value.position.dy)
               ..scale(computedScale);
-            if (widget.enableRotation) {
+            if (widget.enableRotation || value is PhotoViewControllerExplicitValue) {
               matrix..rotateZ(value.rotation);
             }
 


### PR DESCRIPTION
When PhotoView's `enableRotation` is disabled it is not possible to manually rotate the photo view, however the rotation values are still passed to `outputStateStream` as though the rotation had been applied.

This pull request ensures that a manual rotation value is not included in the stream's values when `enableRotation` is not enabled.

Relates to issue #261 .