### PR TITLE
Allow programmatic rotate when PhotoView enableRotation is disabled

### DIFF
--- a/example/lib/screens/examples/rotation_examples.dart
+++ b/example/lib/screens/examples/rotation_examples.dart
@@ -1,12 +1,14 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:photo_view/photo_view.dart';
 import 'package:photo_view_example/screens/common/app_bar.dart';
 
-class RotationExamples extends StatelessWidget {
+class GestureRotationExample extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ExampleAppBarLayout(
-      title: "Rotation Example",
+      title: "Rotation Examples",
       showGoBack: true,
       child: Column(
         children: <Widget>[
@@ -17,20 +19,91 @@ class RotationExamples extends StatelessWidget {
               style: const TextStyle(fontSize: 18.0),
             ),
           ),
-          Container(
-            margin: const EdgeInsets.symmetric(vertical: 20.0),
-            height: 300.0,
-            child: ClipRect(
-              child: PhotoView(
-                imageProvider: const AssetImage("assets/large-image.jpg"),
-                maxScale: PhotoViewComputedScale.covered,
-                initialScale: PhotoViewComputedScale.contained * 0.8,
-                enableRotation: true,
-              ),
-            ),
+          Expanded(
+            child: Container(
+                margin: const EdgeInsets.symmetric(vertical: 20.0),
+                height: 300.0,
+                child: ClipRect(
+                  child: PhotoView(
+                    imageProvider: const AssetImage("assets/large-image.jpg"),
+                    maxScale: PhotoViewComputedScale.covered,
+                    initialScale: PhotoViewComputedScale.contained * 0.8,
+                    enableRotation: true,
+                  ),
+                )),
           ),
         ],
       ),
     );
+  }
+}
+
+class ProgrammaticRotationExample extends StatefulWidget {
+  @override
+  _ProgrammaticRotationExampleState createState() =>
+      _ProgrammaticRotationExampleState();
+}
+
+class _ProgrammaticRotationExampleState
+    extends State<ProgrammaticRotationExample> {
+  final PhotoViewController _controller = PhotoViewController();
+  var _quarterTurns = 0;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          const ExampleAppBar(
+            title: "Programmatic Rotation Example",
+            showGoBack: true,
+          ),
+          Expanded(
+              child: Column(
+            children: <Widget>[
+              Container(
+                padding: const EdgeInsets.all(20.0),
+                child: const Text(
+                  "Example without manual rotation, click the button to rotate",
+                  style: const TextStyle(fontSize: 18.0),
+                ),
+              ),
+              Expanded(
+                child: Container(
+                    margin: const EdgeInsets.symmetric(vertical: 20.0),
+                    height: 300.0,
+                    child: ClipRect(
+                      child: PhotoView(
+                        controller: _controller,
+                        imageProvider:
+                            const AssetImage("assets/large-image.jpg"),
+                        maxScale: PhotoViewComputedScale.covered,
+                        initialScale: PhotoViewComputedScale.contained * 0.8,
+                        enableRotation: false,
+                      ),
+                    )),
+              ),
+            ],
+          ))
+        ],
+      ),
+      floatingActionButton: FloatingActionButton(
+        child: Icon(Icons.rotate_right),
+        onPressed: _rotateRight90Degrees,
+      ),
+    );
+  }
+
+  void _rotateRight90Degrees() {
+    // Set the rotation to either 0, 90, 180 or 270 degrees (value is in radians)
+    _quarterTurns = _quarterTurns == 3 ? 0 : _quarterTurns + 1;
+    _controller.rotation = math.pi / 2 * _quarterTurns;
   }
 }

--- a/example/lib/screens/home_screen.dart
+++ b/example/lib/screens/home_screen.dart
@@ -48,6 +48,30 @@ class HomeScreen extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
+                        builder: (_) => GalleryExample(),
+                      ),
+                    );
+                  },
+                  text: "Gallery",
+                ),
+                _buildItem(
+                  context,
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => HeroExample(),
+                      ),
+                    );
+                  },
+                  text: "Hero animation",
+                ),
+                _buildItem(
+                  context,
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
                         builder: (context) => NetworkExamples(),
                       ),
                     );
@@ -84,42 +108,6 @@ class HomeScreen extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (context) => RotationExamples(),
-                      ),
-                    );
-                  },
-                  text: "Rotation Gesture",
-                ),
-                _buildItem(
-                  context,
-                  onPressed: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (_) => HeroExample(),
-                      ),
-                    );
-                  },
-                  text: "Hero animation",
-                ),
-                _buildItem(
-                  context,
-                  onPressed: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (_) => GalleryExample(),
-                      ),
-                    );
-                  },
-                  text: "Gallery",
-                ),
-                _buildItem(
-                  context,
-                  onPressed: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
                         builder: (_) => CustomChildExample(),
                       ),
                     );
@@ -137,6 +125,30 @@ class HomeScreen extends StatelessWidget {
                     );
                   },
                   text: "Integrated to dialogs",
+                ),
+                _buildItem(
+                  context,
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => GestureRotationExample(),
+                      ),
+                    );
+                  },
+                  text: "Rotation Gesture",
+                ),
+                _buildItem(
+                  context,
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => ProgrammaticRotationExample(),
+                      ),
+                    );
+                  },
+                  text: "Rotation Programmatic",
                 ),
               ],
             ),

--- a/lib/src/controller/photo_view_controller.dart
+++ b/lib/src/controller/photo_view_controller.dart
@@ -93,6 +93,7 @@ class PhotoViewControllerValue {
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is PhotoViewControllerValue &&
+          runtimeType == other.runtimeType &&
           position == other.position &&
           scale == other.scale &&
           rotation == other.rotation &&

--- a/lib/src/controller/photo_view_controller.dart
+++ b/lib/src/controller/photo_view_controller.dart
@@ -111,18 +111,6 @@ class PhotoViewControllerValue {
   }
 }
 
-/// The state value stored and streamed by [PhotoViewController] when a rotation is
-/// is explicitly applied, even if PhotoViewController.enabledRotation is not enabled.
-@immutable
-class PhotoViewControllerExplicitValue extends PhotoViewControllerValue {
-  const PhotoViewControllerExplicitValue({
-    @required Offset position,
-    @required double scale,
-    @required double rotation,
-    @required Offset rotationFocusPoint,
-  }) : super(position: position, scale: scale, rotation: rotation, rotationFocusPoint: rotationFocusPoint);
-}
-
 /// The default implementation of [PhotoViewControllerBase].
 ///
 /// Containing a [ValueNotifier] it stores the state in the [value] field and streams
@@ -245,7 +233,7 @@ class PhotoViewController
       return;
     }
     prevValue = value;
-    value = PhotoViewControllerExplicitValue(
+    value = PhotoViewControllerValue(
       position: position,
       scale: scale,
       rotation: rotation,

--- a/lib/src/controller/photo_view_controller.dart
+++ b/lib/src/controller/photo_view_controller.dart
@@ -93,7 +93,6 @@ class PhotoViewControllerValue {
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is PhotoViewControllerValue &&
-          runtimeType == other.runtimeType &&
           position == other.position &&
           scale == other.scale &&
           rotation == other.rotation &&
@@ -110,6 +109,18 @@ class PhotoViewControllerValue {
   String toString() {
     return 'PhotoViewControllerValue{position: $position, scale: $scale, rotation: $rotation, rotationFocusPoint: $rotationFocusPoint}';
   }
+}
+
+/// The state value stored and streamed by [PhotoViewController] when a rotation is
+/// is explicitly applied, even if PhotoViewController.enabledRotation is not enabled.
+@immutable
+class PhotoViewControllerExplicitValue extends PhotoViewControllerValue {
+  const PhotoViewControllerExplicitValue({
+    @required Offset position,
+    @required double scale,
+    @required double rotation,
+    @required Offset rotationFocusPoint,
+  }) : super(position: position, scale: scale, rotation: rotation, rotationFocusPoint: rotationFocusPoint);
 }
 
 /// The default implementation of [PhotoViewControllerBase].
@@ -234,7 +245,7 @@ class PhotoViewController
       return;
     }
     prevValue = value;
-    value = PhotoViewControllerValue(
+    value = PhotoViewControllerExplicitValue(
       position: position,
       scale: scale,
       rotation: rotation,

--- a/lib/src/core/photo_view_core.dart
+++ b/lib/src/core/photo_view_core.dart
@@ -301,7 +301,7 @@ class PhotoViewCoreState extends State<PhotoViewCore>
             final matrix = Matrix4.identity()
               ..translate(value.position.dx, value.position.dy)
               ..scale(computedScale);
-            if (widget.enableRotation) {
+            if (widget.enableRotation || value is PhotoViewControllerExplicitValue) {
               matrix..rotateZ(value.rotation);
             }
 

--- a/lib/src/core/photo_view_core.dart
+++ b/lib/src/core/photo_view_core.dart
@@ -300,10 +300,8 @@ class PhotoViewCoreState extends State<PhotoViewCore>
 
             final matrix = Matrix4.identity()
               ..translate(value.position.dx, value.position.dy)
-              ..scale(computedScale);
-            if (widget.enableRotation || value is PhotoViewControllerExplicitValue) {
-              matrix..rotateZ(value.rotation);
-            }
+              ..scale(computedScale)
+              ..rotateZ(value.rotation);
 
             final Widget customChildLayout = CustomSingleChildLayout(
               delegate: _CenterWithOriginalSizeDelegate(

--- a/lib/src/core/photo_view_core.dart
+++ b/lib/src/core/photo_view_core.dart
@@ -143,8 +143,8 @@ class PhotoViewCoreState extends State<PhotoViewCore>
     updateMultiple(
       scale: newScale,
       position: clampPosition(position: delta * details.scale),
-      rotation: _rotationBefore + details.rotation,
-      rotationFocusPoint: details.focalPoint,
+      rotation: widget.enableRotation ? _rotationBefore + details.rotation : null,
+      rotationFocusPoint: widget.enableRotation ? details.focalPoint : null,
     );
   }
 

--- a/lib/src/core/photo_view_core.dart
+++ b/lib/src/core/photo_view_core.dart
@@ -143,7 +143,8 @@ class PhotoViewCoreState extends State<PhotoViewCore>
     updateMultiple(
       scale: newScale,
       position: clampPosition(position: delta * details.scale),
-      rotation: widget.enableRotation ? _rotationBefore + details.rotation : null,
+      rotation:
+          widget.enableRotation ? _rotationBefore + details.rotation : null,
       rotationFocusPoint: widget.enableRotation ? details.focalPoint : null,
     );
   }


### PR DESCRIPTION
**Originally #259**

Allows the photo view to be rotated by setting the PhotoViewController.rotation property even when the photo view's enableRotation property is not enabled.

Relates to issue #257.