### PR TITLE
Disabling double tap with an optional Boolean to improve response time for single-tap-only uses

### DIFF
--- a/lib/photo_view.dart
+++ b/lib/photo_view.dart
@@ -258,6 +258,7 @@ class PhotoView extends StatefulWidget {
     this.gestureDetectorBehavior,
     this.tightMode,
     this.filterQuality,
+    this.doubleTapDisabled
   })  : child = null,
         childSize = null,
         super(key: key);
@@ -289,6 +290,7 @@ class PhotoView extends StatefulWidget {
     this.gestureDetectorBehavior,
     this.tightMode,
     this.filterQuality,
+    this.doubleTapDisabled,
   })  : loadFailedChild = null,
         imageProvider = null,
         gaplessPlayback = false,
@@ -378,6 +380,9 @@ class PhotoView extends StatefulWidget {
 
   /// Quality levels for image filters.
   final FilterQuality filterQuality;
+
+  ///disables double tap zoom
+  final bool doubleTapDisabled;
 
   @override
   State<StatefulWidget> createState() {
@@ -552,6 +557,7 @@ class _PhotoViewState extends State<PhotoView> {
       gestureDetectorBehavior: widget.gestureDetectorBehavior,
       tightMode: widget.tightMode ?? false,
       filterQuality: widget.filterQuality ?? FilterQuality.none,
+      doubleTapDisabled: widget.doubleTapDisabled,
     );
   }
 
@@ -609,6 +615,7 @@ class _PhotoViewState extends State<PhotoView> {
       gestureDetectorBehavior: widget.gestureDetectorBehavior,
       tightMode: widget.tightMode ?? false,
       filterQuality: widget.filterQuality ?? FilterQuality.none,
+      doubleTapDisabled: widget.doubleTapDisabled,
     );
   }
 

--- a/lib/photo_view_gallery.dart
+++ b/lib/photo_view_gallery.dart
@@ -333,7 +333,6 @@ class PhotoViewGalleryPageOptions {
     this.gestureDetectorBehavior,
     this.tightMode,
     this.filterQuality,
-    this.doubleTapDisabled
   })  : child = null,
         childSize = null,
         assert(imageProvider != null);
@@ -354,7 +353,6 @@ class PhotoViewGalleryPageOptions {
     this.gestureDetectorBehavior,
     this.tightMode,
     this.filterQuality,
-    this.doubleTapDisabled
   })  : imageProvider = null,
         assert(child != null);
 
@@ -405,7 +403,4 @@ class PhotoViewGalleryPageOptions {
 
   /// Quality levels for image filters.
   final FilterQuality filterQuality;
-
-  /// disabled double tap zoom
-  final bool doubleTapDisabled;
 }

--- a/lib/photo_view_gallery.dart
+++ b/lib/photo_view_gallery.dart
@@ -114,6 +114,7 @@ class PhotoViewGallery extends StatefulWidget {
     this.scrollPhysics,
     this.scrollDirection = Axis.horizontal,
     this.customSize,
+    this.doubleTapDisabled
   })  : itemCount = null,
         builder = null,
         assert(pageOptions != null),
@@ -138,6 +139,7 @@ class PhotoViewGallery extends StatefulWidget {
     this.scrollPhysics,
     this.scrollDirection = Axis.horizontal,
     this.customSize,
+    this.doubleTapDisabled,
   })  : pageOptions = null,
         assert(itemCount != null),
         assert(builder != null),
@@ -187,6 +189,9 @@ class PhotoViewGallery extends StatefulWidget {
 
   /// The axis along which the [PageView] scrolls. Mirror to [PageView.scrollDirection]
   final Axis scrollDirection;
+
+  /// disabled double tap zoom
+  final bool doubleTapDisabled;
 
   bool get _isBuilder => builder != null;
 
@@ -265,6 +270,7 @@ class _PhotoViewGalleryState extends State<PhotoViewGallery> {
             tightMode: pageOption.tightMode,
             filterQuality: pageOption.filterQuality,
             basePosition: pageOption.basePosition,
+            doubleTapDisabled: widget.doubleTapDisabled,
           )
         : PhotoView(
             key: ObjectKey(index),
@@ -289,6 +295,7 @@ class _PhotoViewGalleryState extends State<PhotoViewGallery> {
             tightMode: pageOption.tightMode,
             filterQuality: pageOption.filterQuality,
             basePosition: pageOption.basePosition,
+            doubleTapDisabled: widget.doubleTapDisabled,
           );
 
     return ClipRect(
@@ -326,6 +333,7 @@ class PhotoViewGalleryPageOptions {
     this.gestureDetectorBehavior,
     this.tightMode,
     this.filterQuality,
+    this.doubleTapDisabled
   })  : child = null,
         childSize = null,
         assert(imageProvider != null);
@@ -346,6 +354,7 @@ class PhotoViewGalleryPageOptions {
     this.gestureDetectorBehavior,
     this.tightMode,
     this.filterQuality,
+    this.doubleTapDisabled
   })  : imageProvider = null,
         assert(child != null);
 
@@ -396,4 +405,7 @@ class PhotoViewGalleryPageOptions {
 
   /// Quality levels for image filters.
   final FilterQuality filterQuality;
+
+  /// disabled double tap zoom
+  final bool doubleTapDisabled;
 }

--- a/lib/src/core/photo_view_core.dart
+++ b/lib/src/core/photo_view_core.dart
@@ -326,7 +326,7 @@ class PhotoViewCoreState extends State<PhotoViewCore>
                 ),
                 decoration: widget.backgroundDecoration ?? _defaultDecoration,
               ),
-              onDoubleTap: nextScaleState,
+              //onDoubleTap: nextScaleState,
               onScaleStart: onScaleStart,
               onScaleUpdate: onScaleUpdate,
               onScaleEnd: onScaleEnd,

--- a/lib/src/core/photo_view_core.dart
+++ b/lib/src/core/photo_view_core.dart
@@ -38,6 +38,7 @@ class PhotoViewCore extends StatefulWidget {
     @required this.basePosition,
     @required this.tightMode,
     @required this.filterQuality,
+    this.doubleTapDisabled,
   })  : customChild = null,
         super(key: key);
 
@@ -57,6 +58,7 @@ class PhotoViewCore extends StatefulWidget {
     @required this.basePosition,
     @required this.tightMode,
     @required this.filterQuality,
+    this.doubleTapDisabled,
   })  : imageProvider = null,
         gaplessPlayback = false,
         super(key: key);
@@ -81,6 +83,7 @@ class PhotoViewCore extends StatefulWidget {
   final bool tightMode;
 
   final FilterQuality filterQuality;
+  final bool doubleTapDisabled;
 
   @override
   State<StatefulWidget> createState() {
@@ -326,7 +329,9 @@ class PhotoViewCoreState extends State<PhotoViewCore>
                 ),
                 decoration: widget.backgroundDecoration ?? _defaultDecoration,
               ),
-              onDoubleTap: null,
+              onDoubleTap: widget.doubleTapDisabled!=null && widget.doubleTapDisabled
+                  ? null
+                  : nextScaleState,
               onScaleStart: onScaleStart,
               onScaleUpdate: onScaleUpdate,
               onScaleEnd: onScaleEnd,

--- a/lib/src/core/photo_view_core.dart
+++ b/lib/src/core/photo_view_core.dart
@@ -326,7 +326,7 @@ class PhotoViewCoreState extends State<PhotoViewCore>
                 ),
                 decoration: widget.backgroundDecoration ?? _defaultDecoration,
               ),
-              //onDoubleTap: nextScaleState,
+              onDoubleTap: null,
               onScaleStart: onScaleStart,
               onScaleUpdate: onScaleUpdate,
               onScaleEnd: onScaleEnd,


### PR DESCRIPTION
I am pretty new to programming and have been working with this widget for a while. My application only needs the single tap functionality, but needs it to work in fast repetitions, meaning that the delay by the gesture detector, which is a result of it waiting for the second tap, in case it is a double tap, was really frustrating. I added a single boolean that can be given to a PhotoView or PhotoViewGallery to disable the double tap, called 'disableDoubleTap'
If 'disableDoubleTap' is null, nothing changes. Only if 'disableDoubleTap' is true, things change, the onDoubleTap: of the Gesture Detector of the PhotoViewCore class becomes null.
This results in faster responsiveness for single tap only applications like mine. 
I don't think that this breaks anything, as it's really simple and changes nothing, if 'disableDoubleTap' isn't declared. 
