### PR TITLE
Added `disableDoubleTap` property

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -5,7 +5,6 @@ linter:
   rules:
     - always_declare_return_types
     - always_put_control_body_on_new_line
-    - always_require_non_null_named_parameters
     - annotate_overrides
     - avoid_classes_with_only_static_members
     - avoid_empty_else
@@ -27,10 +26,8 @@ linter:
     - empty_statements
     - hash_and_equals
     - implementation_imports
-    - iterable_contains_unrelated_type
     - library_names
     - library_prefixes
-    - list_remove_unrelated_type
     - no_adjacent_strings_in_list
     - no_duplicate_case_values
     - non_constant_identifier_names
@@ -46,7 +43,6 @@ linter:
     - prefer_const_declarations
     - prefer_const_literals_to_create_immutables
     - prefer_contains
-    - prefer_equal_for_default_values
     - prefer_final_fields
     - prefer_final_locals
     - prefer_foreach

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -5,7 +5,6 @@ linter:
   rules:
     - always_declare_return_types
     - always_put_control_body_on_new_line
-    - always_require_non_null_named_parameters
     - annotate_overrides
     - avoid_classes_with_only_static_members
     - avoid_empty_else
@@ -27,10 +26,8 @@ linter:
     - empty_statements
     - hash_and_equals
     - implementation_imports
-    - iterable_contains_unrelated_type
     - library_names
     - library_prefixes
-    - list_remove_unrelated_type
     - no_adjacent_strings_in_list
     - no_duplicate_case_values
     - non_constant_identifier_names
@@ -46,7 +43,6 @@ linter:
     - prefer_const_declarations
     - prefer_const_literals_to_create_immutables
     - prefer_contains
-    - prefer_equal_for_default_values
     - prefer_final_fields
     - prefer_final_locals
     - prefer_foreach

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -5,7 +5,7 @@ void main() => runApp(MyApp());
 
 ThemeData theme = ThemeData(
   primaryColor: Colors.black,
-  backgroundColor: Colors.white10,
+  scaffoldBackgroundColor: Colors.white10,
   fontFamily: 'PTSans',
 );
 

--- a/example/lib/screens/common/example_button.dart
+++ b/example/lib/screens/common/example_button.dart
@@ -34,7 +34,7 @@ class ExampleButtonNode extends StatelessWidget {
               onPressed: onPressed,
               child: const Text("Open example"),
               style: ButtonStyle(
-                backgroundColor: MaterialStateProperty.all(Colors.amber),
+                backgroundColor: WidgetStateProperty.all(Colors.amber),
               ),
             ),
           )

--- a/example/lib/screens/home_screen.dart
+++ b/example/lib/screens/home_screen.dart
@@ -162,7 +162,7 @@ class HomeScreen extends StatelessWidget {
       {required String text, required VoidCallback onPressed}) {
     return TextButton(
       style: ButtonStyle(
-        padding: MaterialStateProperty.all(
+        padding: WidgetStateProperty.all(
           const EdgeInsets.symmetric(vertical: 25.0, horizontal: 20.0),
         ),
       ),

--- a/lib/photo_view.dart
+++ b/lib/photo_view.dart
@@ -260,6 +260,7 @@ class PhotoView extends StatefulWidget {
     this.tightMode,
     this.filterQuality,
     this.disableGestures,
+    this.disableDoubleTap,
     this.errorBuilder,
     this.enablePanAlways,
     this.strictScale,
@@ -297,6 +298,7 @@ class PhotoView extends StatefulWidget {
     this.tightMode,
     this.filterQuality,
     this.disableGestures,
+    this.disableDoubleTap,
     this.enablePanAlways,
     this.strictScale,
   })  : errorBuilder = null,
@@ -404,9 +406,14 @@ class PhotoView extends StatefulWidget {
   /// Quality levels for image filters.
   final FilterQuality? filterQuality;
 
-  // Removes gesture detector if `true`.
-  // Useful when custom gesture detector is used in child widget.
+  /// Removes the gesture detector when 'true', disabling all gesture-based commands.
+  /// This is useful if a custom gesture detector is implemented in a child widget.
   final bool? disableGestures;
+
+  /// Disables double-tap gesture when `true`. This disables the scale state cycle.
+  /// Useful for assigning another command to the double-tap gesture.
+  /// This property is ignored if [disableGestures] is true.
+  final bool? disableDoubleTap;
 
   /// Enable pan the widget even if it's smaller than the hole parent widget.
   /// Useful when you want to drag a widget without restrictions.
@@ -534,6 +541,7 @@ class _PhotoViewState extends State<PhotoView>
                 tightMode: widget.tightMode,
                 filterQuality: widget.filterQuality,
                 disableGestures: widget.disableGestures,
+                disableDoubleTap: widget.disableDoubleTap,
                 enablePanAlways: widget.enablePanAlways,
                 strictScale: widget.strictScale,
               )
@@ -561,6 +569,7 @@ class _PhotoViewState extends State<PhotoView>
                 tightMode: widget.tightMode,
                 filterQuality: widget.filterQuality,
                 disableGestures: widget.disableGestures,
+                disableDoubleTap: widget.disableDoubleTap,
                 errorBuilder: widget.errorBuilder,
                 enablePanAlways: widget.enablePanAlways,
                 strictScale: widget.strictScale,

--- a/lib/src/core/photo_view_core.dart
+++ b/lib/src/core/photo_view_core.dart
@@ -41,6 +41,7 @@ class PhotoViewCore extends StatefulWidget {
     required this.tightMode,
     required this.filterQuality,
     required this.disableGestures,
+    required this.disableDoubleTap,
     required this.enablePanAlways,
     required this.strictScale,
   })  : customChild = null,
@@ -64,6 +65,7 @@ class PhotoViewCore extends StatefulWidget {
     required this.tightMode,
     required this.filterQuality,
     required this.disableGestures,
+    required this.disableDoubleTap,
     required this.enablePanAlways,
     required this.strictScale,
   })  : imageProvider = null,
@@ -92,6 +94,7 @@ class PhotoViewCore extends StatefulWidget {
   final HitTestBehavior? gestureDetectorBehavior;
   final bool tightMode;
   final bool disableGestures;
+  final bool disableDoubleTap;
   final bool enablePanAlways;
   final bool strictScale;
 
@@ -355,7 +358,7 @@ class PhotoViewCoreState extends State<PhotoViewCore>
 
             return PhotoViewGestureDetector(
               child: child,
-              onDoubleTap: nextScaleState,
+              onDoubleTap: widget.disableDoubleTap == true ? null : nextScaleState,
               onScaleStart: onScaleStart,
               onScaleUpdate: onScaleUpdate,
               onScaleEnd: onScaleEnd,

--- a/lib/src/photo_view_wrappers.dart
+++ b/lib/src/photo_view_wrappers.dart
@@ -31,6 +31,7 @@ class ImageWrapper extends StatefulWidget {
     required this.tightMode,
     required this.filterQuality,
     required this.disableGestures,
+    required this.disableDoubleTap,
     required this.errorBuilder,
     required this.enablePanAlways,
     required this.strictScale,
@@ -60,6 +61,7 @@ class ImageWrapper extends StatefulWidget {
   final bool? tightMode;
   final FilterQuality? filterQuality;
   final bool? disableGestures;
+  final bool? disableDoubleTap;
   final bool? enablePanAlways;
   final bool? strictScale;
 
@@ -203,6 +205,7 @@ class _ImageWrapperState extends State<ImageWrapper> {
       tightMode: widget.tightMode ?? false,
       filterQuality: widget.filterQuality ?? FilterQuality.none,
       disableGestures: widget.disableGestures ?? false,
+      disableDoubleTap: widget.disableDoubleTap ?? false,
       enablePanAlways: widget.enablePanAlways ?? false,
     );
   }
@@ -253,6 +256,7 @@ class CustomChildWrapper extends StatelessWidget {
     required this.tightMode,
     required this.filterQuality,
     required this.disableGestures,
+    required this.disableDoubleTap,
     required this.enablePanAlways,
     required this.strictScale,
   }) : super(key: key);
@@ -281,6 +285,7 @@ class CustomChildWrapper extends StatelessWidget {
   final bool? tightMode;
   final FilterQuality? filterQuality;
   final bool? disableGestures;
+  final bool? disableDoubleTap;
   final bool? enablePanAlways;
   final bool? strictScale;
 
@@ -312,6 +317,7 @@ class CustomChildWrapper extends StatelessWidget {
       tightMode: tightMode ?? false,
       filterQuality: filterQuality ?? FilterQuality.none,
       disableGestures: disableGestures ?? false,
+      disableDoubleTap: disableDoubleTap ?? false,
       enablePanAlways: enablePanAlways ?? false,
     );
   }


### PR DESCRIPTION
Added `disableDoubleTap` property and fixed lint issues from recent Dart and Flutter updates.

The property disables double-tap gesture when `true`. This disables the scale state cycle.
Useful for assigning another command to the double-tap gesture.
This property is ignored if [disableGestures] is true.


