### PR TITLE
[Fix] Image drifting and sliding during simultaneous zoom and pan

### DIFF
--- a/lib/src/core/photo_view_core.dart
+++ b/lib/src/core/photo_view_core.dart
@@ -143,7 +143,16 @@ class PhotoViewCoreState extends State<PhotoViewCore>
   void onScaleStart(ScaleStartDetails details) {
     _rotationBefore = controller.rotation;
     _scaleBefore = scale;
-    _normalizedPosition = details.focalPoint - controller.position;
+
+    // Determine the pivot point (transform origin) based on the widget's base position.
+    final Offset transformOrigin =
+        widget.basePosition.alongSize(widget.scaleBoundaries.outerSize);
+
+    // Store the vector from the image's current position to the focal point.
+    // This allows us to maintain the focal point relative to the image content during scaling.
+    _normalizedPosition =
+        details.focalPoint - transformOrigin - controller.position;
+
     _scaleAnimationController.stop();
     _positionAnimationController.stop();
     _rotationAnimationController.stop();
@@ -151,7 +160,15 @@ class PhotoViewCoreState extends State<PhotoViewCore>
 
   void onScaleUpdate(ScaleUpdateDetails details) {
     final double newScale = _scaleBefore! * details.scale;
-    final Offset delta = details.focalPoint - _normalizedPosition!;
+
+    final Offset transformOrigin =
+        widget.basePosition.alongSize(widget.scaleBoundaries.outerSize);
+
+    // Apply the current scale delta to the relative focal vector.
+    final Offset delta = _normalizedPosition! * details.scale;
+
+    // Calculate the new position so that the focal point remains fixed relative to the image.
+    final Offset newPosition = details.focalPoint - transformOrigin - delta;
 
     if (widget.strictScale &&
         (newScale > widget.scaleBoundaries.maxScale ||
@@ -164,8 +181,8 @@ class PhotoViewCoreState extends State<PhotoViewCore>
     updateMultiple(
       scale: newScale,
       position: widget.enablePanAlways
-          ? delta
-          : clampPosition(position: delta * details.scale),
+          ? newPosition
+          : clampPosition(position: newPosition),
       rotation:
           widget.enableRotation ? _rotationBefore! + details.rotation : null,
       rotationFocusPoint: widget.enableRotation ? details.focalPoint : null,


### PR DESCRIPTION
### The Issue (User Perspective)
When a user places two fingers on the screen to zoom in (pinch) and moves their hand across the screen at the same time (pan), the image behaves unnaturally. To try this, put two fingers really close together, zoom in using the fingers, then stay on the screen with the two fingers and move them around together. The image will now move below your fingers faster then your fingers are moving.

Instead of "sticking" to the user's fingers, the image appears to slide away or move faster than the fingers themselves. It feels like the image is on a slippery surface; if you zoom in while dragging, the image overshoots the intended position. Additionally, the zoom often feels like it is pulling towards the bottom-right corner rather than staying centered between the two fingers.

**Expected Behavior:** The specific point of the image underneath the user's fingers should remain exactly under their fingers throughout the entire gesture, regardless of how much they zoom or move.

### Technical Detail
The issue stemmed from two logic errors in `photo_view_core.dart`:

1.  **Translation Scaling:** The previous logic multiplied the calculated translation offset by the current scale factor. This meant that the more the user zoomed in, the faster the image would pan, causing the "overshoot" effect.
2.  **Incorrect Pivot Point:** The math previously assumed the transformation origin was always the top-left corner `(0,0)`. However, `PhotoView` usually defaults to `Alignment.center`. This mismatch caused the image to drift away from the center of the pinch gesture.

### The Fix
The logic in `onScaleStart` and `onScaleUpdate` has been updated to use vector math relative to the correct `transformOrigin` (based on `basePosition`).

We now calculate the vector from the image's current position to the user's focal point. During the update, we apply the scale delta specifically to that vector and subtract it from the current focal point. This ensures the image stays legally anchored to the touch gesture.

### Type of Change
- [x] Bug fix (non-breaking change which fixes a layout/gesture issue)

### Checklist
- [x] Tested with `Alignment.center` (default)
- [x] Verified simultaneous pinch-zoom-pan gestures "stick" to fingers
- [x] Verified `strictScale` behavior remains intact